### PR TITLE
RDKBACCL-1085:Enabling the webui packages in ARM System Ready.

### DIFF
--- a/conf/include/rdk-bbmasks-rdkb-platform.inc
+++ b/conf/include/rdk-bbmasks-rdkb-platform.inc
@@ -120,8 +120,6 @@ BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-gwprovapp-epon.bb"
 BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-wifi-agent.bb"
 BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-mta-agent.bb"
 BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/rdktelcovoicemanager.bb"
-BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-jst.bb"
-BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-php.bb"
 
 BBMASK .= "|meta-cmf-broadband/recipes-core/util-linux/util-linux_%.bbappend"
 

--- a/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -10,9 +10,6 @@ RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "rdktelcovoicemanager"
 
 RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "ccsp-adv-security"
 
-RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "ccsp-webui-jst"
-RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "ccsp-webui-php"
-
 RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "parodus"
 
 RDEPENDS_packagegroup-rdk-ccsp-broadband_append = "\


### PR DESCRIPTION
Reason For Change: Webui packages are not enabled in ARM System Ready.
Test Procedure:webui service and scripts should be part rootfs.
Risks: Low