### PR TITLE
RDKBACCL-1271:Missing CcspWebUI.service and CcspWebui.sh in ARM system.

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-jst.bbappend
@@ -1,0 +1,31 @@
+require ccsp_common_genericarm.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+EXTRA_OECONF += "PHP_RPATH=no"
+
+SRC_URI += "${CMF_GIT_ROOT}/rdkb/devices/raspberrypi/sysint;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/devices;name=webuijst"
+SRCREV_webuijst = "${AUTOREV}"
+SRC_URI_append = " \
+    file://CcspWebUI.sh \
+    file://CcspWebUI.service \
+"
+
+inherit systemd
+
+do_install_append () {
+    install -d ${D}${sysconfdir}
+    install -d ${D}${base_libdir}/rdk/
+    install -d ${D}${systemd_unitdir}/system/
+
+    install -m 755 ${WORKDIR}/CcspWebUI.sh ${D}${base_libdir}/rdk/
+    install -m 644 ${WORKDIR}/CcspWebUI.service ${D}${systemd_unitdir}/system/
+}
+
+SYSTEMD_SERVICE_${PN} += "CcspWebUI.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+
+FILES_${PN} += " \
+    ${systemd_unitdir}/system/CcspWebUI.service \
+    ${base_libdir}/rdk/* \
+"

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/files/CcspWebUI.service
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/files/CcspWebUI.service
@@ -1,0 +1,36 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2019 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+[Unit]
+Description=CcspWebUI service
+After=gwprovethwan.service
+Wants=gwprovethwan.service
+
+[Service]
+Type=forking
+WorkingDirectory=/usr/www2
+ExecStart=/bin/sh /lib/rdk/CcspWebUI.sh
+Restart=always
+StandardOutput=syslog+console
+
+[Install]
+WantedBy=multi-user.target
+
+
+

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/files/CcspWebUI.sh
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/files/CcspWebUI.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2019 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+
+sleep 10
+
+LIGHTTPD_PROCESS=`ps aux | grep lighttpd | grep -v grep | wc -l`
+
+if [ $LIGHTTPD_PROCESS = 0 ]; then
+        /bin/sh /etc/webgui.sh
+else
+        echo "Lighttpd process was already running"
+        exit 0
+fi
+


### PR DESCRIPTION
Reason For Change: The ARM system does not contain the required WebUI service files. Both CcspWebUI.service and CcspWebUI.sh are missing
Test procedure: rootfs should have CcspWebUI.service and CcspWebui.sh.
Risks: Low