### PR TITLE
[main] manifests: change clone branch for meta-rdk-bsp-arm to 'main'

### DIFF
--- a/manifests/rdkb-bsp-arm.xml
+++ b/manifests/rdkb-bsp-arm.xml
@@ -6,7 +6,7 @@
     <remote name="openembedded" fetch="https://git.openembedded.org" review=""/>
     <default remote="cmf" revision="rdkb-2025q1-kirkstone" sync-j="2"/>
     <include name="manifests/oe-layers.xml"/>
-    <project name="rdkcentral/meta-rdk-bsp-arm" remote="github" path="meta-rdk-bsp-arm" revision="develop"/>
+    <project name="rdkcentral/meta-rdk-bsp-arm" remote="github" path="meta-rdk-bsp-arm" revision="main"/>
     <project name="components/opensource/OMI"/>
     <project name="components/opensource/gdbus-client"/>
     <project name="rdk/components/generic/OvsAgent"/>


### PR DESCRIPTION
The manifest in the "main" branch should pull the `main` branch of `meta-rdk-bsp-arm` instead of `develop`.