### PR TITLE
RDKBACCL-1323: Update ARM System Ready Revision to rdk-next

### DIFF
--- a/manifests/rdkb-bsp-arm.xml
+++ b/manifests/rdkb-bsp-arm.xml
@@ -4,42 +4,117 @@
     <remote name="github" fetch="https://github.com" review=""/>
     <remote name="yocto" fetch="http://git.yoctoproject.org/git" review=""/>
     <remote name="openembedded" fetch="https://git.openembedded.org" review=""/>
-    <default remote="cmf" revision="rdk-next" sync-j="2"/>
+    <default remote="cmf" revision="master" sync-j="2"/>
     <include name="manifests/oe-layers.xml"/>
-    <project name="rdkcentral/meta-rdk-bsp-arm" remote="github" path="meta-rdk-bsp-arm" revision="develop"/>
+    <project name="rdkcentral/meta-rdk-bsp-arm" remote="github" path="meta-rdk-bsp-arm" revision="main"/>
+    <project name="components/opensource/OMI"/>
     <project name="components/opensource/gdbus-client"/>
-    <project name="rdk/components/generic/libSyscallWrapper"/>
-    <project name="rdk/components/generic/libunpriv"/>
-    <project name="rdk/components/generic/rdk-oe/meta-cmf" path="meta-cmf"/>
-    <project name="rdk/components/generic/rdk-oe/meta-cmf-broadband" path="meta-cmf-broadband"/>
-    <project name="rdk/components/generic/rdk-oe/meta-cmf-mesh" path="meta-cmf-mesh"/>
-    <project name="rdk/components/generic/rdk-oe/meta-rdk" path="meta-rdk"/>
-    <project name="rdk/components/generic/rdk-oe/meta-rdk-broadband" path="meta-rdk-broadband"/>
-    <project name="rdk/components/generic/rdk-oe/meta-rdk-ext" path="meta-rdk-ext"/>
-    <project name="rdk/components/generic/rdkssa"/>
-    <project name="rdk/components/generic/sys_mon_tools/mem_analyser_tools"/>
-    <project name="rdk/components/generic/sys_mon_tools/sys_resource"/>
-    <project name="rdk/components/generic/syslog_helper"/>
-    <project name="rdk/devices/raspberrypi/webpa-client"/>
-    <project name="rdkb/components/generic/CcspLogAgent"/>
-    <project name="rdkb/components/generic/sso"/>
-    <project name="rdkb/components/opensource/ccsp/CcspEPONAgent"/>
+    <project name="rdk/components/generic/OvsAgent" revision="rdk-next"/>
+    <project name="rdk/components/generic/WebconfigFramework" revision="rdk-next"/>
+    <project name="rdk/components/generic/breakpad_wrapper" revision="rdk-next" />
+    <project name="rdk/components/generic/cpuprocanalyzer" revision="rdk-next"/>
+    <project name="rdk/components/generic/crashupload" revision="rdk-next"/>
+    <project name="rdk/components/generic/dca" revision="rdk-next"/>
+    <project name="rdk/components/generic/dcm" revision="rdk-next"/>
+    <project name="rdk/components/generic/jst" revision="rdk-next"/>
+    <project name="rdk/components/generic/libSyscallWrapper" revision="rdk-next"/>
+    <project name="rdk/components/generic/libunpriv" revision="rdk-next"/>
+    <project name="rdk/components/generic/lxc-container-generator"/>
+    <project name="rdk/components/generic/lxccpid"/>
+    <project name="rdk/components/generic/rdk-oe/meta-cmf" path="meta-cmf" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk-oe/meta-cmf-broadband" path="meta-cmf-broadband" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk-oe/meta-cmf-mesh" path="meta-cmf-mesh" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk-oe/meta-rdk" path="meta-rdk" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk-oe/meta-rdk-broadband" path="meta-rdk-broadband" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk-oe/meta-rdk-ext" path="meta-rdk-ext" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdk_logger" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdkssa" revision="rdk-next"/>
+    <project name="rdk/components/generic/rdm" revision="rdk-next"/>
+    <project name="rdk/components/generic/rfc" revision="rdk-next"/>
+    <project name="rdk/components/generic/sys_mon_tools/mem_analyser_tools" revision="rdk-next"/>
+    <project name="rdk/components/generic/sys_mon_tools/sys_resource" revision="rdk-next"/>
+    <project name="rdk/components/generic/syslog_helper" revision="rdk-next"/>
+    <project name="rdk/components/generic/telemetry" revision="rdk-next"/>
+    <project name="rdk/components/generic/xupnp" revision="rdk-next"/>
+    <project name="rdk/devices/raspberrypi/webpa-client" revision="rdk-next"/>
+    <project name="rdkb/components/generic/CcspLogAgent" revision="rdk-next"/>
+    <project name="rdkb/components/generic/harvester" revision="rdk-next"/>
+    <project name="rdkb/components/generic/json-rpc" revision="rdk-next"/>
+    <project name="rdkb/components/generic/mtu_modifier" revision="rdk-next"/>
+    <project name="rdkb/components/generic/notify_comp" revision="rdk-next"/>
+    <project name="rdkb/components/generic/sso" revision="rdk-next"/>
+    <project name="rdkb/components/generic/startParodus" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspCMAgent" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspCommonLibrary" revision="rdk-next" />
+    <project name="rdkb/components/opensource/ccsp/CcspCr" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspDmCli" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspEPONAgent" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspEthAgent" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspHomeSecurity" revision="rdk-next" />
+    <project name="rdkb/components/opensource/ccsp/CcspLMLite" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspMisc" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspMoCA" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspMtaAgent" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspPandM" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspPsm" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspSnmpPa" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CcspTr069Pa" revision="rdk-next"/>
     <project name="rdkb/components/opensource/ccsp/CcspWifiAgent" revision="main"/>
-    <project name="rdkb/components/opensource/ccsp/FirmwareSanity"/>
-    <project name="rdkb/components/opensource/ccsp/GwProvApp-ePON"/>
-    <project name="rdkb/components/opensource/ccsp/PlatformManager"/>
-    <project name="rdkb/components/opensource/ccsp/RdkTelcoVoiceManager"/>
-    <project name="rdkb/components/opensource/ccsp/sysint"/>
+    <project name="rdkb/components/opensource/ccsp/CcspXDNS" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/CoreNetLib" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/DhcpManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/FirmwareSanity" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/GwProvApp" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/GwProvApp-EthWan" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/GwProvApp-ePON" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/LanManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/MeshAgent" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/OneWifi" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/PlatformManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/PowerManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkCellularManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkCellularManager-MM" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkInterDeviceManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkLedManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkPlatformManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/RdkTelcoVoiceManager" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/TestAndDiagnostic" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/Utopia" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/Xconf" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/hal" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/hal/rdk-wifi-hal" path="rdkb/components/opensource/ccsp/rdk-wifi-hal" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/halinterface" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/hotspot" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/sysint" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/webui" revision="rdk-next"/>
+    <project name="rdkb/components/opensource/ccsp/webui-bwg" revision="rdk-next"/>
+    <project name="rdkb/devices/ci20/hal"/>
+    <project name="rdkb/devices/emulator/hal" revision="rdk-next" />
     <project name="rdkb/devices/intel-x86-pc/emulator/sysint" path="rdkb/components/opensource/ccsp/sysint/device" revision="rdk-next"/>
     <project name="rdkb/devices/intel-x86-pc/emulator/tdkb" path="rdkb/tools/tdkb/platform/rdkbemulator" revision="rdk-next"/>
-    <project name="rdkb/devices/raspberrypi/sysint" path="rdkb/components/opensource/ccsp/sysint/devicerpi"/>
-    <project name="rdkb/devices/raspberrypi/tdkb" path="rdkb/tools/tdkb/platform/raspberrypi"/>
-    <project name="rdkb/devices/rdkbemu/rdkbemu_xb3" path="rdkb/components/opensource/ccsp/xb3"/>
-    <project name="rdkb/tools/tdkb"/>
+    <project name="rdkb/devices/raspberrypi/sysint" path="rdkb/components/opensource/ccsp/sysint/devicegenericarm" revision="rdk-next"/>
+    <project name="rdkb/devices/raspberrypi/tdkb" path="rdkb/tools/tdkb/platform/raspberrypi" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/generic/CcspLogAgent/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/generic/harvester/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspCr/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspLMLite/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspPandM/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspPsm/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspSnmpPa/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspTr069Pa/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/CcspWifiAgent/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/TestAndDiagnostic/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/Utopia/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/ccsp/rdkb" path="rdkb/components/opensource/ccsp/hotspot/devices" revision="rdk-next"/>
+    <project name="rdkb/devices/rdkbemu/rdkbemu_xb3" path="rdkb/components/opensource/ccsp/xb3" revision="rdk-next"/>
+    <project name="rdkb/docs"/>
+    <project name="rdkb/tools/tdkb" revision="rdk-next"/>
     <project name="rdkcentral/RdkEasyMeshController" remote="github" path="rdkb/components/opensource/ccsp/RdkEasyMeshController" revision="main"/>
     <project name="rdkcentral/RdkEasyMeshControllerSSP" remote="github" path="rdkb/components/opensource/ccsp/RdkEasyMeshController/ssp" revision="main"/>
     <project name="rdkcentral/hal-voice-asterisk" remote="github" path="components/opensource/hal-voice-asterisk" revision="main"/>
-    <project name="rdkcentral/hal-wifi-cfg80211" remote="github" path="components/opensource/hal-wifi-cfg80211" revision="master"/>
+    <project name="rdkcentral/hal-wifi-cfg80211" remote="github" path="components/opensource/hal-wifi-cfg80211"/>
     <project name="rdkcentral/meta-rdk-wan" remote="github" path="meta-rdk-wan" revision="main"/>
+    <project name="rdkcentral/rdkb-emu-hal" remote="github" path="rdkb/devices/rdkbemu/hal"/>
     <project name="rdkcentral/rdkb-halif-platform" remote="github" path="rdkb/components/opensource/ccsp/rdkb-halif-platform" revision="main"/>
+    <project name="rdkcentral/zilker-sdk" remote="github" path="components/opensource/zilker-sdk" revision="main"/>
 </manifest>


### PR DESCRIPTION
Reason For Change: Currenlty Arm manifest.xml is using 2025Q1-kirkstone revision
Test Procedure: repo initialise from rdk-next revision
Risks:Low