### PR TITLE
Factory Reset support on ARM System Ready

### DIFF
--- a/meta-rdk-broadband/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-broadband/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -58,6 +58,8 @@ do_install:append() {
     touch ${D}/nvram2/.placeholder
     ln -s -r ${D}/rdklogs/logs2 ${D}/nvram2/logs
 
+    sed -i "/if \[ \! -f \/usr\/bin\/GetConfigFile \]\;then/,+4d" ${D}/rdklogger/logfiles.sh
+
     #self heal support
     install -d ${D}/usr/ccsp/tad
     install -m 0755 ${S}/devicegenericarm/lib/rdk/corrective_action.sh ${D}/usr/ccsp/tad


### PR DESCRIPTION
Fixed FR failure by removing GetConfigFile dependency in /rdklogger/logfiles.sh

Factory Reset (FR) on ARM platform was failing because /rdklogger/backupLogs.sh exited prematurely while sourcing /rdklogger/logfiles.sh.

The exit was triggered by a check for a missing binary (/usr/bin/GetConfigFile), which caused logfiles.sh to execute exit 127. Since the file was sourced, this terminated the main FR backup script before completion.

Tested on the NXP and RPI, FR is working as expected. attached the log.
[FR_ARM_test.log](https://github.com/user-attachments/files/25258878/FR_ARM_test.log)
