### PR TITLE
[#41] ccsp-eth-agent: re-instate use of CcspHalEthSw_RegisterLinkEventCallback

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -6,9 +6,10 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/ccsp-eth-agent:"
 
 SRC_URI:remove = "${CMF_GITHUB_ROOT}/ethernet-agent;protocol=https;nobranch=1"
 SRC_URI = "git://github.com/rdkcentral/ethernet-agent.git;protocol=https;branch=develop"
-SRCREV_pn-ccsp-eth-agent = "e350f19aa5c0802c35ec520d9e1484b0033fc250"
+SRCREV_pn-ccsp-eth-agent = "3a0058c9699a15f9190fbdc02e411c9a541294f5"
 
 SRC_URI:append = "\
     file://0001-genericarm-increase-maximum-number-of-Ethernet-interfaces.patch \
+    file://0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch \
     "
 

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch
@@ -1,0 +1,34 @@
+From bbfd1b81f62dd32c8bc14a52d1d9fbcf61984e66 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Mon, 16 Feb 2026 22:09:25 +1100
+Subject: [PATCH] cosa_ethernet_internal: force
+ CcspHalEthSw_RegisterLinkEventCallback use on generic arm
+
+---
+ source/TR-181/middle_layer_src/cosa_ethernet_internal.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+index f13eb0b..e48d018 100644
+--- a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
++++ b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+@@ -394,10 +394,15 @@ CosaEthernetInitialize
+ 	    EthWanLinkUp_callback();
+     }
+ #endif //WAN_FAILOVER_SUPPORTED
+-#elif defined(FEATURE_RDKB_WAN_AGENT)
++#if defined(_PLATFORM_GENERICARM_)
+     CosaDmlEthInit(NULL, (PANSC_HANDLE)pMyObject);
+     CcspHalEthSw_RegisterLinkEventCallback(CosaDmlEthPortLinkStatusCallback); //Register cb for link event.
+ #endif
++
++#elif defined(FEATURE_RDKB_WAN_AGENT)
++    CosaDmlEthInit(NULL, (PANSC_HANDLE)pMyObject);
++    CcspHalEthSw_RegisterLinkEventCallback(CosaDmlEthPortLinkStatusCallback); //Register cb for link event.
++#endif // FEATURE_RDKB_WAN_MANAGER
+     CcspHalExtSw_ethAssociatedDevice_callback_register(CosaDmlEth_AssociatedDevice_callback);
+     CosaEthTelemetryxOpsLogSettingsSync();
+     if (CosaEthTelemetryInit() < 0) {
+-- 
+2.51.2
+


### PR DESCRIPTION
This resolves #41 and other instances where non-Fiber WAN interfaces failed to start (such as https://github.com/rdkcentral/meta-rdk-bsp-arm/issues/40#issuecomment-3895267684 )

In commit 761cc79 this modification was removed as it looked like the problem was fixed "upstream" (in ethernet-agent), but it was actually only for when the "WAN Agent" feature was used (as opposed to `FEATURE_RDKB_WAN_MANAGER` and `WAN_FAILOVER_SUPPORTED`)

We need to use the Link Event callback so that WAN Manager knows the PHY status of Ethernet interfaces used for WAN. When it doesn't, the Device.Ethernet.X_RDK_Interface.X.Status attribute will be stuck on "Down".

In the future, these custom HAL implementations should be replaced by using the kernel [Distributed Switch Architecture](https://docs.kernel.org/networking/dsa/dsa.html)

