### PR TITLE
[#49] Turn off unified-wifi-mesh by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+conf/distro/include/local-settings.inc

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ $ source meta-rdk-bsp-arm/setup-environment
 $ bitbake rdk-generic-broadband-image
 ```
 
+If you need to enable features such as unified-wifi-mesh/EasyMesh, you can do this
+by creating the `conf/distro/include/local-settings.inc` (under your local
+copy of `meta-rdk-bsp-arm`), like so:
+
+```
+echo 'DISTRO_FEATURES:append:broadband = " EasyMesh"' >> conf/distro/include/local-settings.inc
+```
+
 At the current time, the `main` branch mainfest will build RDK-B 2025Q1 (based on Yocto `kirkstone`),
 and will be updated following the next major RDK-B release.
 

--- a/conf/distro/include/rdk-genericarm.inc
+++ b/conf/distro/include/rdk-genericarm.inc
@@ -167,12 +167,6 @@ DISTRO_FEATURES:append:broadband = " partner_default_ext"
 # Remove WebUI (does not work without erouter0)
 DISTRO_FEATURES:remove:broadband = " webui_jst"
 
-# Add new EasyMesh
-DISTRO_FEATURES:append:broadband = " EasyMesh"
-
-# Add IEEE1905 AL
-DISTRO_FEATURES:append:broadband = " with_alsap"
-
 # Disable eMTA feature
 DISTRO_FEATURES:append:broadband = " no_mta_support"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,5 +17,6 @@ LAYERDEPENDS_meta-rdk-bsp-arm = "core"
 LAYERSERIES_COMPAT_meta-rdk-bsp-arm = "kirkstone"
 
 include conf/distro/include/rdk-genericarm.inc
+include conf/distro/include/local-settings.inc
 include conf/include/rdk-external-src-platform.inc
 include conf/include/rdk-bbmasks-rdkb-platform.inc

--- a/meta-rdk-broadband/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/unified-wifi-mesh/unified-wifi-mesh.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://remove_broadcast_test.patch"
 
+CPPFLAGS:append = " -DAL_SAP"
+
 # These will be handled by unified-wifi-mesh-personality packages
 do_install:append() {
     rm -rf ${D}${systemd_unitdir}/system/


### PR DESCRIPTION
Introduce a `local-settings.inc` file which is masked by `.gitignore`.

Feature flags like EasyMesh can be re-enabled like this:
```
echo 'DISTRO_FEATURES:append:broadband = " EasyMesh"' >> conf/distro/include/local-settings.inc
```