### PR TITLE
[#54] image: remove lighttpd from image when WebUI not enabled

### DIFF
--- a/recipes-core/images/rdk-generic-broadband-boot-image.bb
+++ b/recipes-core/images/rdk-generic-broadband-boot-image.bb
@@ -19,15 +19,4 @@ SYSTEMD_TOOLS:remove:libc-musl = "systemd-bootchart"
 
 IMAGE_INSTALL:append = " ${SYSTEMD_TOOLS}"
 
-ROOTFS_POSTPROCESS_COMMAND += "add_systemd_services; "
-
-add_systemd_services() {
-                if [ -d ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/multi-user.target.wants/ ]; then
-                        rm -f ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/multi-user.target.wants/connman.service;
-                fi
-                if [ ! -f ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/multi-user.target.wants/lighttpd.service ]; then
-                        ln -sf ${IMAGE_ROOTFS}${systemd_unitdir}/system/lighttpd.service ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/multi-user.target.wants/lighttpd.service
-                fi
-}
-
 

--- a/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
@@ -8,6 +8,8 @@ RDEPENDS_packagegroup-rdk-oss-broadband:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'dac', 'speedtest-cli', '', d)} \
 "
 
+RDEPENDS_packagegroup-rdk-oss-broadband:remove = " lighttpd"
+
 RDEPENDS_packagegroup-rdk-oss-broadband:append = " virtual/wifi-vendor-mtk"
 RDEPENDS_packagegroup-rdk-oss-broadband:append = " virtual/firmware-mtk-wifi6"
 RDEPENDS_packagegroup-rdk-oss-broadband:remove:aarch64 = "alljoyn"


### PR DESCRIPTION
Even though no WebUI related flags are enabled, lighttpd was still being included in the image.