### PR TITLE
[2025.Q4] Apply Ethernet agent link status fix

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -10,5 +10,6 @@ SRCREV_pn-ccsp-eth-agent = "e350f19aa5c0802c35ec520d9e1484b0033fc250"
 
 SRC_URI:append = "\
     file://0001-genericarm-increase-maximum-number-of-Ethernet-interfaces.patch \
+    file://0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch \
     "
 

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch
@@ -1,0 +1,34 @@
+From bbfd1b81f62dd32c8bc14a52d1d9fbcf61984e66 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Mon, 16 Feb 2026 22:09:25 +1100
+Subject: [PATCH] cosa_ethernet_internal: force
+ CcspHalEthSw_RegisterLinkEventCallback use on generic arm
+
+---
+ source/TR-181/middle_layer_src/cosa_ethernet_internal.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+index f13eb0b..e48d018 100644
+--- a/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
++++ b/source/TR-181/middle_layer_src/cosa_ethernet_internal.c
+@@ -394,10 +394,15 @@ CosaEthernetInitialize
+ 	    EthWanLinkUp_callback();
+     }
+ #endif //WAN_FAILOVER_SUPPORTED
+-#elif defined(FEATURE_RDKB_WAN_AGENT)
++#if defined(_PLATFORM_GENERICARM_)
+     CosaDmlEthInit(NULL, (PANSC_HANDLE)pMyObject);
+     CcspHalEthSw_RegisterLinkEventCallback(CosaDmlEthPortLinkStatusCallback); //Register cb for link event.
+ #endif
++
++#elif defined(FEATURE_RDKB_WAN_AGENT)
++    CosaDmlEthInit(NULL, (PANSC_HANDLE)pMyObject);
++    CcspHalEthSw_RegisterLinkEventCallback(CosaDmlEthPortLinkStatusCallback); //Register cb for link event.
++#endif // FEATURE_RDKB_WAN_MANAGER
+     CcspHalExtSw_ethAssociatedDevice_callback_register(CosaDmlEth_AssociatedDevice_callback);
+     CosaEthTelemetryxOpsLogSettingsSync();
+     if (CosaEthTelemetryInit() < 0) {
+-- 
+2.51.2
+


### PR DESCRIPTION
This is the version of #51 for the 2025.Q4 / `main` branch
--------------------

In commit 761cc79 this modification was removed as it looked like the problem was fixed "upstream", but it was actually only for when the "WAN Agent" feature was used.

We need to use the Link Event callback so that WAN Manager knows the PHY status of Ethernet interfaces used for WAN. When it doesn't, the Device.Ethernet.X_RDK_Interface.X.Status attribute will be stuck on "Down".

(cherry picked from commit c61f0e873689491617cc04d90d3ea1c8bc328e02)