### PR TITLE
Disable core-net-lib DISTRO_FEATURE for ARM

### DIFF
--- a/conf/distro/include/rdk-genericarm.inc
+++ b/conf/distro/include/rdk-genericarm.inc
@@ -122,8 +122,6 @@ DISTRO_FEATURES:append:broadband = " device_gateway_association"
 # REFPLTB-1546 : WiFi HAL 3.0 support for RPI
 DISTRO_FEATURES:append:broadband = " halVersion3"
 
-# RDKB-44824: CoreNetLib move bb file location
-DISTRO_FEATURES:append:broadband = " core-net-lib"
 
 # DKBDEV-1455 : Support Broadband DAC
 DISTRO_FEATURES:append:broadband = " dac"


### PR DESCRIPTION
In RDK-B reference platforms such as RPi and BPI, core-net-lib is not enabled, and WAN interface handling does not use the CoreNetLib approach. Instead, the interface rename is performed using standard system commands:

Proposed Change:

Disable core-net-lib in the ARM broadband distro configuration so that: The non-CoreNetLib WAN rename path is compiled.
ARM behavior aligns with RPi and BPI RDK-B platforms.

Expected Outcome:

WAN interface rename handled via v_secure_system path. erouter0 comes up successfully and obtains a valid IP.