### PR TITLE
Use systemd notifications to sequence CcspEthAgent and RdkWanManager

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -32,6 +32,11 @@ SRC_URI:append = " file://0002-systemd_units-correct-wan_started-path-for-read-o
 # Remove call to migration_to_psm.sh, utopiaInitCheck.sh and log_psm_db.sh
 SRC_URI:append = " file://0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-call.patch"
 
+# Modify CcspEthAgent systemd unit to use systemd notifications,
+# and RdkWanManager wait for CcspEthAgent's notify event
+SRC_URI:append = " file://0004-systemd-ccsp-eth-agent-sd-notify.patch"
+SRC_URI:append = " file://0005-systemd-rdk-wan-manager-eth-agent.patch"
+
 do_configure:prepend:aarch64() {
 	sed -e '/len/ s/^\/*/\/\//' -i ${S}/source/ccsp/components/common/DataModel/dml/components/DslhObjRecord/dslh_objro_access.c
 }
@@ -114,8 +119,6 @@ do_install:append:class-target () {
      DISTRO_WAN_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','true','false',d)}"
      if [ $DISTRO_WAN_ENABLED = 'true' ]; then
      install -D -m 0644 ${S}/systemd_units/RdkWanManager.service ${D}${systemd_unitdir}/system/RdkWanManager.service
-     sed -i "s/After=CcspCrSsp.service/After=CcspCrSsp.service utopia.service /g" ${D}${systemd_unitdir}/system/RdkWanManager.service
-     sed -i "s/CcspPandMSsp.service/CcspCrSsp.service CcspPandMSsp.service/g" ${D}${systemd_unitdir}/system/CcspEthAgent.service
      install -D -m 0644 ${WORKDIR}/utopia.service ${D}${systemd_unitdir}/system/utopia.service
      install -D -m 0644 ${S}/systemd_units/RdkTelcoVoiceManager.service ${D}${systemd_unitdir}/system/RdkTelcoVoiceManager.service
      install -D -m 0644 ${S}/systemd_units/RdkVlanManager.service ${D}${systemd_unitdir}/system/RdkVlanManager.service

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0004-systemd-ccsp-eth-agent-sd-notify.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0004-systemd-ccsp-eth-agent-sd-notify.patch
@@ -1,0 +1,35 @@
+From 874755e3181fc681d6bce992f7111ae67aee4ce2 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Thu, 26 Feb 2026 13:14:41 +1100
+Subject: [PATCH] (meta-rdk-bsp-arm only) CcspEthAgent: use systemd
+ notifications
+
+We will use sd_notify to signal (in our ethernet monitoring thread)
+that we are ready to generate events for downstream consumers
+(such as WanManager)
+---
+ systemd_units/CcspEthAgent.service | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/systemd_units/CcspEthAgent.service b/systemd_units/CcspEthAgent.service
+index 260ac94..b5ff2f9 100644
+--- a/systemd_units/CcspEthAgent.service
++++ b/systemd_units/CcspEthAgent.service
+@@ -22,12 +22,12 @@ Description=CcspEthAgent service
+ After=CcspPandMSsp.service
+ 
+ [Service]
+-Type=forking
++Type=notify
+ WorkingDirectory=/usr/ccsp/ethagent
+ Environment="Subsys=eRT."
+ Environment="LOG4C_RCPATH=/etc"
+ EnvironmentFile=/etc/device.properties
+-ExecStart=/bin/sh -c '/usr/bin/CcspEthAgent -subsys $Subsys'
++ExecStart=/usr/bin/CcspEthAgent -subsys ${Subsys}
+ ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspEthAgent" >> ${PROCESS_RESTART_LOG}'
+ SyslogIdentifier=CcspEthAgent
+ Restart=always
+-- 
+2.51.2
+

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0005-systemd-rdk-wan-manager-eth-agent.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0005-systemd-rdk-wan-manager-eth-agent.patch
@@ -1,0 +1,28 @@
+From 344ebb3a2f5ab37b3b0352007fc73d255ffd277b Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Thu, 26 Feb 2026 13:45:23 +1100
+Subject: [PATCH] (meta-rdk-bsp-arm only) systemd_units: Make RdkWanManager
+ wait for CcspEthAgent
+
+---
+ systemd_units/RdkWanManager.service | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/systemd_units/RdkWanManager.service b/systemd_units/RdkWanManager.service
+index 0915391..fa1c529 100644
+--- a/systemd_units/RdkWanManager.service
++++ b/systemd_units/RdkWanManager.service
+@@ -18,8 +18,9 @@
+ ##########################################################################
+ [Unit]
+ Description=Rdk Wan Manager service
++Requires=CcspEthAgent.service
+ 
+-After=CcspCrSsp.service PsmSsp.service
++After=CcspEthAgent.service
+ 
+ [Service]
+ Type=forking
+-- 
+2.51.2
+

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -19,4 +19,7 @@ CFLAGS:append = " -DUSE_SYSTEMD_NOTIFICATIONS"
 DEPENDS:append = " systemd"
 LDFLAGS:append = " -lsystemd"
 
-SRC_URI:append = " file://0003-Send-READY-notification-to-systemd-when-data-model-ready.patch"
+SRC_URI:append = " \
+    file://0003-Send-READY-notification-to-systemd-when-data-model-ready.patch \
+    file://0004-main-do-not-background-fork-when-systemd-notification.patch \
+"

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -13,3 +13,10 @@ SRC_URI:append = "\
     file://0002-cosa_ethernet_internal-force-CcspHalEthSw_RegisterLink.patch \
     "
 
+# For systemd notifications
+
+CFLAGS:append = " -DUSE_SYSTEMD_NOTIFICATIONS"
+DEPENDS:append = " systemd"
+LDFLAGS:append = " -lsystemd"
+
+SRC_URI:append = " file://0003-Send-READY-notification-to-systemd-when-data-model-ready.patch"

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0003-Send-READY-notification-to-systemd-when-data-model-ready.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0003-Send-READY-notification-to-systemd-when-data-model-ready.patch
@@ -1,0 +1,41 @@
+From db11581e29d7bb3fe88b9695f2c43a05cf33e4fe Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Fri, 27 Feb 2026 09:59:44 +1100
+Subject: [PATCH] Send READY notification to systemd when data model ready.
+
+This is to allow the start of consumer services (by systemd)
+to be correctly sequenced based on Ethernet Agent's availability.
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+---
+ source/TR-181/middle_layer_src/plugin_main_apis.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/source/TR-181/middle_layer_src/plugin_main_apis.c b/source/TR-181/middle_layer_src/plugin_main_apis.c
+index 9961260..ee64f30 100644
+--- a/source/TR-181/middle_layer_src/plugin_main_apis.c
++++ b/source/TR-181/middle_layer_src/plugin_main_apis.c
+@@ -77,6 +77,10 @@
+ extern int sock;
+ #endif
+ 
++#if defined(USE_SYSTEMD_NOTIFICATIONS)
++#include <systemd/sd-daemon.h>
++#endif
++
+ /**********************************************************************
+ 
+     caller:     owner of the object
+@@ -173,6 +177,9 @@ CosaBackEndManagerInitialize
+ 
+     printf("CosaEthInferface initialization done!\n");
+ 
++#if defined(USE_SYSTEMD_NOTIFICATIONS)
++    sd_notify(0,"READY=1");
++#endif
+     return returnStatus;
+ }
+ 
+-- 
+2.51.2
+

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0004-main-do-not-background-fork-when-systemd-notification.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-eth-agent/0004-main-do-not-background-fork-when-systemd-notification.patch
@@ -1,0 +1,28 @@
+From 9426c04bd2f96ef0dcf9f61fcfa900bd48dc1398 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Tue, 3 Mar 2026 10:06:54 +1100
+Subject: [PATCH] main: do not background / fork when systemd notification
+ feature enabled
+
+systemd notifications require the  main process thread to remain active
+---
+ source/EthSsp/ssp_main.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/source/EthSsp/ssp_main.c b/source/EthSsp/ssp_main.c
+index f87704e..5154f76 100644
+--- a/source/EthSsp/ssp_main.c
++++ b/source/EthSsp/ssp_main.c
+@@ -320,9 +320,10 @@ int main(int argc, char* argv[])
+     }
+ 
+     pComponentName          = CCSP_COMPONENT_NAME_ETHAGENT;
+-
+-    if ( bRunAsDaemon )
++    #if !defined(USE_SYSTEMD_NOTIFICATIONS)
++    if ( bRunAsDaemon)
+         daemonize();
++    #endif
+ 
+ CcspTraceInfo(("\nAfter daemonize before signal\n"));
+ 

--- a/meta-rdk-broadband/recipes-ccsp/hal/hal-ethsw-generic/ccsp_hal_ethsw.c
+++ b/meta-rdk-broadband/recipes-ccsp/hal/hal-ethsw-generic/ccsp_hal_ethsw.c
@@ -150,7 +150,7 @@ void *ethsw_thread_main(void *context __attribute__((unused)))
         }
         for(x=0; x<ETH_INTF_MAX; x++) {
             snprintf(eth_intf_names,32,"eth%d", x);
-            if ((err = rtnl_link_get_kernel(sk, 0, &eth_intf_names, &link)) < 0) {
+            if ((err = rtnl_link_get_kernel(sk, 0, (char *)&eth_intf_names[0], &link)) < 0) {
                 /* Ignore "missing" interfaces */
                 if (err == -NLE_NODEV)
                     continue;

--- a/meta-rdk-broadband/recipes-ccsp/hal/hal-ethsw-generic/ccsp_hal_ethsw.c
+++ b/meta-rdk-broadband/recipes-ccsp/hal/hal-ethsw-generic/ccsp_hal_ethsw.c
@@ -40,6 +40,8 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
+
 #include <net/if.h>
 #include <stdbool.h>
 #include <pthread.h>
@@ -67,7 +69,10 @@ appCallBack ethWanCallbacks;
 #define  ETH_INITIALIZE  "/tmp/ethagent_initialized"
 #define  LINK_VALUE_SIZE  50
 #define  ETH_WAN_IFNAME   "eth8"
+#define WAN_MANAGER_INITIALIZED_PATH "/tmp/wanmanager_initialized"
+
 #endif
+
 
 INT (*linkEventCallback)(CHAR *ifname, CHAR *state) = NULL;
 
@@ -98,6 +103,19 @@ typedef enum {
 #define ETHOE_STATUS_DOWN_TEXT      "Down"
 
 #if defined(FEATURE_RDKB_WAN_MANAGER)
+
+int wait_for_wan_manager(void)
+{
+    struct stat statbuf;
+    int stat_ret = -1;
+
+    while((stat_ret == stat(WAN_MANAGER_INITIALIZED_PATH, &statbuf)) != 0) {
+        sleep(1);
+    }
+
+    return stat_ret;
+}
+
 void *ethsw_thread_main(void *context __attribute__((unused)))
 {
     FILE *fp = NULL;
@@ -115,12 +133,14 @@ void *ethsw_thread_main(void *context __attribute__((unused)))
     previous_link_status_t link_statuses[ETH_INTF_MAX];
     
     CcspHalEthSwTrace(("%s called\n", __func__));
-
-    sleep(60);
   
     for(x=0; x<ETH_INTF_MAX; x++) {
         link_statuses[x] = FIRST_RUN;
     }
+
+    CcspHalEthSwTrace(("%s: Waiting for WAN Manager to start\n", __func__));
+    /* Wait for WAN Manager to start and become ready */
+    wait_for_wan_manager();
 
     CcspHalEthSwTrace(("%s: Netlink version active\n", __func__));
     while(1) {


### PR DESCRIPTION
This has been identified as a factor in our Ethernet Agent / WAN Manager issues (#62)

The ethernet agent will now use systemd notifications to signal when it is ready for other services to listen for ethernet link events
WAN Manager now has an explicit dependency on Ethernet Agent.

Additionally, the monitoring thread that is the source of link event notifications will wait for WAN Manager to initialize before starting the monitoring process.

For more information see #38 where systemd notifications were used to improve the consumption of ieee1905 by em_agent/em_ctrl.
