### PR TITLE
Fix common library build (fixes #65)

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0001-service-set-systemd-SyslogIdentifier.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0001-service-set-systemd-SyslogIdentifier.patch
@@ -1,7 +1,7 @@
-From 70984c612378df539ccb38f38e0bbc7187f8e27b Mon Sep 17 00:00:00 2001
+From 3cc45c2a41b7e8217bfa1572c30febe712e5bd2f Mon Sep 17 00:00:00 2001
 From: Mathew McBride <matt@traverse.com.au>
 Date: Wed, 14 Jan 2026 14:55:30 +1100
-Subject: [PATCH 1/3] service: set systemd SyslogIdentifier
+Subject: [PATCH] service: set systemd SyslogIdentifier
 
 A previous changeset made all services invoked
 via the "/bin/sh -c '(...)'" pattern, which causes all
@@ -31,6 +31,7 @@ ident to be applied to the log entries:
 
 PsmSsp[1820]: rdk_dyn_log_initg_dl_socket = 3 __progname = PsmSsp
 CcspEthAgent[3754]: CcspHalExtSw_getAssociatedDevice not implemented on generic arm platforms yet
+
 ---
  systemd_units/CcspCrSsp.service      | 2 +-
  systemd_units/CcspEthAgent.service   | 1 +
@@ -132,10 +133,10 @@ index 0f6df5f..03e5242 100644
  [Install]
  WantedBy=multi-user.target
 diff --git a/systemd_units/PsmSsp.service b/systemd_units/PsmSsp.service
-index 1ac0828..273498d 100644
+index 00bc921..c9938fe 100644
 --- a/systemd_units/PsmSsp.service
 +++ b/systemd_units/PsmSsp.service
-@@ -34,7 +34,7 @@ ExecStart=/bin/sh -c '/usr/bin/PsmSsp -subsys $Subsys'
+@@ -35,7 +35,7 @@ ExecStart=/bin/sh -c '/usr/bin/PsmSsp -subsys $Subsys'
  ExecStartPost=/bin/sh -c '(/etc/migration_to_psm.sh)'
  ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting PsmSsp" >> ${PROCESS_RESTART_LOG}'
  Restart=always
@@ -170,6 +171,3 @@ index ed2914d..f20c78d 100644
  
  [Install]
  WantedBy=multi-user.target
--- 
-2.51.2
-

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0002-systemd_units-correct-wan_started-path-for-read-only.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0002-systemd_units-correct-wan_started-path-for-read-only.patch
@@ -1,10 +1,11 @@
-From d1c4308057ceffeccf3bfc2ad6d1e5eb968ea0aa Mon Sep 17 00:00:00 2001
+From 0ff8852c32d7c307b4f187d9d92836f25e8550c0 Mon Sep 17 00:00:00 2001
 From: Mathew McBride <matt@traverse.com.au>
 Date: Wed, 11 Jun 2025 16:00:48 +1000
-Subject: [PATCH 2/3] systemd_units: correct wan_started path for read-only
- rootfs operation
+Subject: [PATCH] systemd_units: correct wan_started path for read-only rootfs
+ operation
 
 Change-Id: Ic2ea67894ac51797867cb72625c2a0b127350302
+
 ---
  systemd_units/wan-initialized.path | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -22,6 +23,3 @@ index 8136280..40d5b8f 100644
  Unit=wan-initialized.target
  
  [Install]
--- 
-2.51.2
-

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-call.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-call.patch
@@ -1,33 +1,31 @@
-From fa7faa69831d031b969830c739297d7946d80146 Mon Sep 17 00:00:00 2001
+From 3dc3053aa1d13e4b0f36b5d8be84ba9b4518b199 Mon Sep 17 00:00:00 2001
 From: Mathew McBride <matt@traverse.com.au>
 Date: Wed, 14 Jan 2026 15:27:01 +1100
-Subject: [PATCH 3/3] [meta-rdk-bsp-arm only] remove pre and post start calls
- from PsmSsp
+Subject: [PATCH] remove pre and post start calls from PsmSsp
 
 utopiaInitCheck.sh and log_psm_db.sh were already removed by the
 bbappend file.
 
 migration_to_psm.sh has no effect on our platform so remove it as
 well.
+
 ---
- systemd_units/PsmSsp.service | 3 ---
- 1 file changed, 3 deletions(-)
+ systemd_units/PsmSsp.service | 4 ----
+ 1 file changed, 4 deletions(-)
 
 diff --git a/systemd_units/PsmSsp.service b/systemd_units/PsmSsp.service
-index 273498d..7972f5c 100644
+index c9938fe..7972f5c 100644
 --- a/systemd_units/PsmSsp.service
 +++ b/systemd_units/PsmSsp.service
-@@ -28,10 +28,7 @@ WorkingDirectory=/usr/ccsp
+@@ -28,11 +28,7 @@ WorkingDirectory=/usr/ccsp
  Environment="Subsys=eRT."
  Environment="LOG4C_RCPATH=/etc"
  EnvironmentFile=/etc/device.properties
 -ExecStartPre=/bin/sh -c '(/usr/ccsp/utopiaInitCheck.sh)'
 -ExecStartPre=-/bin/sh -c '(/usr/ccsp/log_psm.db.sh)'
+-ExecStartPre=-/bin/sh -c '(/usr/ccsp/migration_for_psm.sh)'
  ExecStart=/bin/sh -c '/usr/bin/PsmSsp -subsys $Subsys'
 -ExecStartPost=/bin/sh -c '(/etc/migration_to_psm.sh)'
  ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting PsmSsp" >> ${PROCESS_RESTART_LOG}'
  Restart=always
  SyslogIdentifier=PsmSsp
--- 
-2.51.2
-


### PR DESCRIPTION
Update the `PsmSsp.service` file to work with recent changes in https://github.com/rdkcentral/common-library/commit/a924949c8dc2491686277d7e822fabe24fcee2af .

Resolves this build error on rdk-next as of 2026-02-26:
```
BBHandledException("Applying '0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-call.patch' failed:
stdout: checking file systemd_units/PsmSsp.service
Hunk #1 FAILED at 28.
1 out of 1 hunk FAILED
```

The other two patches we have against common-library (specifically the systemd unit files supplied) are also refreshed for consistency.