### PR TITLE
[#70] rdk-wanmanager: set version to 2.14 to avoid build error 

### DIFF
--- a/meta-rdk-wan/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
+++ b/meta-rdk-wan/recipes-ccsp/ccsp/rdk-wanmanager.bbappend
@@ -1,2 +1,5 @@
 RDEPENDS:rdk-wanmanager:append = " ndisc6-rdisc6"
 CFLAGS:append = " -D_PLATFORM_RASPBERRYPI_"
+
+# 2026-03-03: Override version due to build failure with v2.15
+SRC_URI="git://github.com/rdkcentral/wan-manager.git;branch=releases/2.14.0-main;protocol=https;name=WanManager;tag=v2.14.0"


### PR DESCRIPTION
WanManager 2.15 is not building with our settings, this issue will be examined at a later time.
(See #69 for error log)

For now, set the WAN Manager version to 2.14.