### PR TITLE
Feature: Change WAN Manager Interface Group for EthWAN

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
@@ -1226,7 +1226,7 @@
   <Record name="dmsb.wanmanager.if.1.Selection.Enable" type="astr">TRUE</Record>
   <Record name="dmsb.wanmanager.if.1.Selection.ActiveLink" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.1.Selection.RequiresReboot" type="astr">FALSE</Record>
-  <Record name="dmsb.wanmanager.if.1.Selection.Group" type="astr">2</Record>
+  <Record name="dmsb.wanmanager.if.1.Selection.Group" type="astr">1</Record>
   <Record name="dmsb.wanmanager.if.1.Selection.Priority" type="astr">1</Record>
   <Record name="dmsb.wanmanager.if.1.Selection.Timeout" type="astr">60</Record>
 


### PR DESCRIPTION
During testing of WAN interface switching, it was observed that when switching from Cellular (wwan0) to EthWAN, the Ethernet WAN interface was temporarily selected, but after the restoration timer expired, WAN Manager switched back to the cellular interface.

This occurred because the EthWAN interface  was configured in Group 2, while the cellular interface (wwan0) belonged to Group 1. WAN Manager always prioritizes interfaces belonging to the lower numbered group, which caused the cellular interface to be reselected automatically.

**Change**

The configuration has been updated to move the EthWAN interface into Group 1.

**Behavior Before Change**

```
Cellular (wwan0) belonged to Group 1
EthWAN(WAN interface) belonged to Group 2
After switching to EthWAN, WAN Manager restoration logic reselected cellular as it had higher priority.
```

**Behavior After Change**

```
EthWAN interface is configured in Group 1
WAN Manager selection behavior aligns correctly with expected WAN switching
```