### PR TITLE
Remove / disable out of scope features (rdm-agent, TelcoVoiceManager, meshAgent)

### DIFF
--- a/conf/distro/include/rdk-genericarm.inc
+++ b/conf/distro/include/rdk-genericarm.inc
@@ -131,9 +131,6 @@ DISTRO_FEATURES:append:broadband = " dac"
 # REFPLTB-1775: Sky team's fix for erouter0 IP issue
 DISTRO_FEATURES:append:broadband = " RbusBuildFlagEnable"
 
-#MeshAgent support for broadband
-DISTRO_FEATURES:append:broadband = " meshwifi"
-
 #rdk-wifi-libhostap support for broadband
 DISTRO_FEATURES:append:broadband = " HOSTAPD_2_11"
 

--- a/conf/distro/include/rdk-genericarm.inc
+++ b/conf/distro/include/rdk-genericarm.inc
@@ -167,6 +167,9 @@ DISTRO_FEATURES:remove:broadband = " webui_jst"
 # Disable eMTA feature
 DISTRO_FEATURES:append:broadband = " no_mta_support"
 
+# Disable RDM
+DISTRO_FEATURES:remove:broadband = " RDM"
+
 SESSIONMGR_WS_RPC_ENABLE = "1"
 
 #REFPLTB-2784 : easymesh controller arch only supports with wifiagent

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -120,7 +120,6 @@ do_install:append:class-target () {
      if [ $DISTRO_WAN_ENABLED = 'true' ]; then
      install -D -m 0644 ${S}/systemd_units/RdkWanManager.service ${D}${systemd_unitdir}/system/RdkWanManager.service
      install -D -m 0644 ${WORKDIR}/utopia.service ${D}${systemd_unitdir}/system/utopia.service
-     install -D -m 0644 ${S}/systemd_units/RdkTelcoVoiceManager.service ${D}${systemd_unitdir}/system/RdkTelcoVoiceManager.service
      install -D -m 0644 ${S}/systemd_units/RdkVlanManager.service ${D}${systemd_unitdir}/system/RdkVlanManager.service
      fi
      DISTRO_FW_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','fwupgrade_manager','true','false',d)}"
@@ -205,5 +204,5 @@ FILES:${PN}:append = " \
     ${systemd_unitdir}/system/wan-initialized.target \
     ${systemd_unitdir}/system/wan-initialized.path \
 "
-FILES:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' ${systemd_unitdir}/system/RdkWanManager.service ${systemd_unitdir}/system/utopia.service ${systemd_unitdir}/system/RdkVlanManager.service ${systemd_unitdir}/system/RdkTelcoVoiceManager.service ', '', d)}"
+FILES:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' ${systemd_unitdir}/system/RdkWanManager.service ${systemd_unitdir}/system/utopia.service ${systemd_unitdir}/system/RdkVlanManager.service  ', '', d)}"
 FILES:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'fwupgrade_manager', ' ${systemd_unitdir}/system/RdkFwUpgradeManager.service ', '', d)}"

--- a/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -15,6 +15,10 @@ RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "ccsp-webui-php"
 
 RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "parodus"
 
+RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'RDM', '', ' rdm-agent', d)} \
+"
+
 RDEPENDS_packagegroup-rdk-ccsp-broadband:append = "\
     rdk-logger \
     libseshat \


### PR DESCRIPTION
* rdm-agent package build does not complete
  From my understanding this feature should not be enabled on open source reference platforms, because other meta layers / files are required to configure it

* Remove TelcoVoiceManager service file
* Disable meshAgent feature (from my examination, this has no use on a purely reference platform)