### PR TITLE
conf: mask out dhcp manager bbappend in meta-cmf-broadband

### DIFF
--- a/conf/include/rdk-bbmasks-rdkb-platform.inc
+++ b/conf/include/rdk-bbmasks-rdkb-platform.inc
@@ -125,4 +125,7 @@ BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-php.bb"
 
 BBMASK .= "|meta-cmf-broadband/recipes-core/util-linux/util-linux_%.bbappend"
 
+# 2026-04-07 meta-cmf-broadband change breaks DHCP Manager install
+BBMASK .= "|meta-cmf-broadband/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bbappend"
+
 BBMASK:append:kirkstone = "|meta-rdk-opensync/recipes/python3-jinja2/python3-jinja2_2.11.1.bb"


### PR DESCRIPTION
Commit [a1143f0677a1 ("RDKBACCL-1603: >95% CPU Utilisation observed for CcspDHCPMgr service")](https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/rdk-oe/meta-cmf-broadband/+/a1143f0677a13fb9c62e303b0da4e4ed48bd43ab) in meta-cmf-broadband added a do_install append which does not check for the existence of CcspDHCPMgr.service first.

This was causing this error:
```
sed: can't read [...]/lib/systemd/system/CcspDHCPMgr.service: No such file or directory
WARNING: exit code 2 from a shell command.
ERROR: Task (mc:generic:rdk-next/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-dhcp-mgr.bb:do_install) failed with exit code '1'
```

