### PR TITLE
Feature: WebPa support in ARM System Ready

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -35,7 +35,7 @@ SRC_URI:append = " file://0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-c
 # Modify CcspEthAgent systemd unit to use systemd notifications,
 # and RdkWanManager wait for CcspEthAgent's notify event
 SRC_URI:append = " file://0004-systemd-ccsp-eth-agent-sd-notify.patch"
-SRC_URI:append = " file://0005-systemd-rdk-wan-manager-eth-agent.patch"
+#SRC_URI:append = " file://0005-systemd-rdk-wan-manager-eth-agent.patch"
 
 do_configure:prepend:aarch64() {
 	sed -e '/len/ s/^\/*/\/\//' -i ${S}/source/ccsp/components/common/DataModel/dml/components/DslhObjRecord/dslh_objro_access.c
@@ -74,6 +74,13 @@ do_install:append:class-target () {
     install -D -m 0644 ${S}/systemd_units/notifyComp.service ${D}${systemd_unitdir}/system/notifyComp.service
     install -D -m 0644 ${S}/systemd_units/CcspTelemetry.service ${D}${systemd_unitdir}/system/CcspTelemetry.service
 
+    #webpa service
+    install -D -m 0644 ${S}/systemd_units/parodus.service ${D}${systemd_unitdir}/system/parodus.service
+    install -D -m 0644 ${S}/systemd_units/webpa.service ${D}${systemd_unitdir}/system/webpa.service
+    sed -i 's/parodusCmd.cmd &/parodusCmd.cmd/' ${D}${systemd_unitdir}/system/parodus.service
+    sed -i '/ExecStart=/a ExecStartPost\=\sysevent set webserver started'  ${D}${systemd_unitdir}/system/parodus.service
+    sed -i "/WorkingDirectory=/a ExecStartPre\=\/bin/sh -c '\/lib/rdk/webpa_pre_setup.sh'\\;" ${D}${systemd_unitdir}/system/webpa.service
+    
     #rfc service file
     install -D -m 0644 ${S}/systemd_units/rfc.service ${D}${systemd_unitdir}/system/rfc.service
 
@@ -176,6 +183,8 @@ SYSTEMD_SERVICE:${PN}:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'fwupgr
 SYSTEMD_SERVICE:${PN}:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'onewifi.service ', 'ccspwifiagent.service', d)}"
 SYSTEMD_SERVICE:${PN}:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', 'webconfig.service', '', d)}"
 SYSTEMD_SERVICE:${PN}:append = " brlan0_check.service"
+SYSTEMD_SERVICE:${PN}:append = " parodus.service"
+SYSTEMD_SERVICE:${PN}:append = " webpa.service"
 
 FILES:${PN}:append = " \
     /usr/ccsp/ccspSysConfigEarly.sh \
@@ -203,6 +212,8 @@ FILES:${PN}:append = " \
     ${systemd_unitdir}/system/CcspXdnsSsp.service \
     ${systemd_unitdir}/system/wan-initialized.target \
     ${systemd_unitdir}/system/wan-initialized.path \
+    ${systemd_unitdir}/system/parodus.service \
+    ${systemd_unitdir}/system/webpa.service \
 "
 FILES:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' ${systemd_unitdir}/system/RdkWanManager.service ${systemd_unitdir}/system/utopia.service ${systemd_unitdir}/system/RdkVlanManager.service  ', '', d)}"
 FILES:${PN}:append = "${@bb.utils.contains('DISTRO_FEATURES', 'fwupgrade_manager', ' ${systemd_unitdir}/system/RdkFwUpgradeManager.service ', '', d)}"

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp.bbappend
@@ -1,0 +1,23 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/parodus2ccsp:"
+  
+SRC_URI += "\
+    file://parodus_read_file.sh \
+    file://parodus_create_file.sh \
+    file://webpa_pre_setup.sh \
+"
+EXTRA_OECMAKE += "-DBUILD_BANANAPI_R4=ON "
+
+do_install_append () {
+    install -d ${D}${base_libdir_native}/rdk
+    install -m 0755 ${WORKDIR}/webpa_pre_setup.sh ${D}${base_libdir_native}/rdk
+    install -d ${D}/etc/parodus
+    install -m 777 ${WORKDIR}/parodus_read_file.sh ${D}/etc/parodus/
+    install -m 777 ${WORKDIR}/parodus_create_file.sh ${D}/etc/parodus/
+
+}
+
+
+FILES_${PN}_append = " \
+     ${base_libdir_native}/rdk/* \
+     /etc/parodus/* \
+     "

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/parodus_create_file.sh
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/parodus_create_file.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2019 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+SER_NUM=$1
+MAC=$2
+TIMEOUT=30
+#TODO add it common config file
+CURL_RESPONSE="/tmp/.cURLresponse"
+CERT_PATH="/etc/ssl/certs/ca-certificates.crt"
+HTTP_CODE="/tmp/cfg_http_code"
+CURL_FILE_RESPONSE="/tmp/adzvfchig-res.mch"
+CONFIG_FILE="/usr/bin/GetConfigFile"
+RDKSSACLI="/usr/bin/rdkssacli"
+DEVICE_CERT="devicecert_1.pk12"
+STATIC_CERT="/etc/ssl/certs/staticXpkiCrt.pk12"
+XPKIEXTRACT="/tmp/.adzvfchigc1ssa"
+CFG_IN="/tmp/.cfgStaticxpki"
+STATICCPGCFG="/tmp/.staticCpgCfg"
+OPENSSLCLI="/usr/bin/openssl"
+CURRENT_INTERFACE="/etc/CURRENT_INTERFACE"
+
+source /etc/device.properties
+source /lib/rdk/getpartnerid.sh
+
+echo_t()
+{
+        echo "`date +"%y%m%d-%T.%6N"` $1"
+}
+
+if [ $DEVICE_TYPE == "broadband" ]; then
+		DEVICE_CERT_PATH=/nvram/certs
+        LOG_PATH="/rdklogs/logs"
+        CONSOLEFILE="$LOG_PATH/WEBCONFIGlog.txt.0"
+        exec 3>&1 4>&2 >>$CONSOLEFILE 2>&1
+elif [ $DEVICE_TYPE == "mediaclient" -o $DEVICE_TYPE == "hybrid" ]; then
+		DEVICE_CERT_PATH=/opt/certs
+else
+		echo_t "WEBCONFIG: $DEVICE_CERT_PATH, not expected"
+		DEVICE_CERT_PATH=/tmp/certs
+fi
+
+getCpgConfig()
+{
+	if [ -f $CONFIG_FILE ]; then
+		$CONFIG_FILE $STATICCPGCFG
+		mv $STATICCPGCFG $CURL_FILE_RESPONSE
+		rm -f $STATICCPGCFG
+	else
+		echo_t "WEBCONFIG: No $CONFIG_FILE to fetch $STATICCPGCFG"
+	fi
+}
+
+#cpu intensive routine hence reduce the usage
+getDeviceConfigFile()
+{
+	if [ ! -f $CURL_FILE_RESPONSE ]; then
+		if [ ! -f $OPENSSLCLI ]; then
+			echo_t "WEBCONFIG: no openssl cli, use cpg config"
+			getCpgConfig
+			return
+		fi
+
+		if [ ! -f $DEVICE_CERT_PATH/$DEVICE_CERT ]; then 
+			if [ -x /usr/bin/rdkssacertcheck.sh ]; then
+				echo_t "WEBCONFIG: Procure xPki Cert"
+				sh /usr/bin/rdkssacertcheck.sh nonotify
+			fi
+		fi
+
+		if [ -f $DEVICE_CERT_PATH/$DEVICE_CERT ]; then
+			if [ -f $RDKSSACLI ]; then
+				openssl pkcs12 -nodes -password pass:$(xxxxxxxxxxxx) -in $DEVICE_CERT_PATH/$DEVICE_CERT -out $XPKIEXTRACT
+				sed -n '/--BEGIN PRIVATE KEY--/,/--END PRIVATE KEY--/p; /--END PRIVATE KEY--/q' $XPKIEXTRACT  > $CURL_FILE_RESPONSE
+				sed -n '/--BEGIN CERTIFICATE--/,/--END CERTIFICATE--/p; /--END CERTIFICATE--/q' $XPKIEXTRACT  >> $CURL_FILE_RESPONSE
+				rm -f $XPKIEXTRACT
+			else
+				echo_t "WEBCONFIG: No $RDKSSACLI support "
+			fi
+		else
+			echo_t "WEBCONFIG: No $DEVICE_CERT_PATH/$DEVICE_CERT using static cert"
+			if [ -f $CONFIG_FILE ]; then
+				$CONFIG_FILE $CFG_IN
+				if [ -f $CFG_IN ]; then
+					openssl pkcs12 -nodes -password pass:$(cat $CFG_IN) -in $STATIC_CERT -out $XPKIEXTRACT
+					sed -n '/--BEGIN PRIVATE KEY--/,/--END PRIVATE KEY--/p; /--END PRIVATE KEY--/q' $XPKIEXTRACT  > $CURL_FILE_RESPONSE
+					sed -n '/--BEGIN CERTIFICATE--/,/--END CERTIFICATE--/p; /--END CERTIFICATE--/q' $XPKIEXTRACT  >> $CURL_FILE_RESPONSE
+					rm -f $XPKIEXTRACT
+				else
+					echo_t "WEBCONFIG: $CFG_IN not available"
+				fi
+			else
+				echo_t "WEBCONFIG: No $CONFIG_FILE to fetch $CFG_IN"
+			fi
+		fi
+	fi
+}
+
+runcURL()
+{
+		getDeviceConfigFile
+
+		if [ -f $CURL_FILE_RESPONSE ]; then
+			UUID=$(uuidgen -r)
+			echo_t "WEBCONFIG: generated uuid is $UUID"
+			echo_t "WEBCONFIG: MAC is $MAC"
+			echo_t "WEBCONFIG: SER_NUM is $SER_NUM"
+			echo_t "WEBCONFIG: Transaction-Id is $UUID"
+			if [ -f $CURRENT_INTERFACE ]; then
+				CURRENT_WAN_INTERFACE=`sysevent get current_wan_ifname`
+				echo_t "WEBCONFIG: WEBCONFIG_CURRENT_INTERFACE is $CURRENT_WAN_INTERFACE"
+			else	
+			echo_t "WEBCONFIG: WEBCONFIG_INTERFACE is $WEBCONFIG_INTERFACE"
+			fi
+			PartnerId=$(getPartnerId)
+			if [ "$PartnerId" == "" ] || [ "$PartnerId" == "unknown" ]; then
+				PartnerId=""
+			else
+				PartnerId="*,$PartnerId"
+			fi
+			echo_t "WEBCONFIG: X-Midt-Partner-Id header is $PartnerId"
+                        SERVER_URL=`psmcli get Device.X_RDKCENTRAL-COM_Webpa.TokenServer.URL` 
+                        echo_t "WEBCONFIG: Server Url is $SERVER_URL"
+                        
+			retry_count=1
+			while [ true ]
+			do
+				if [ "$CURRENT_WAN_INTERFACE" != "" ]; then
+					CURL_TOKEN="curl -w '%{http_code}\n' --interface $CURRENT_WAN_INTERFACE --connect-timeout $TIMEOUT -m $TIMEOUT --output $CURL_RESPONSE -E $CURL_FILE_RESPONSE --header X-Midt-Mac-Address:\"$MAC\" --header X-Midt-Serial-Number:\"$SER_NUM\" --header X-Midt-Uuid:\"$UUID\" --header X-Midt-Transaction-Id:\"$UUID\" --header X-Midt-Partner-Id:\"$PartnerId\" $SERVER_URL"
+				elif [ "$WEBCONFIG_INTERFACE" != "" ]; then
+					CURL_TOKEN="curl -w '%{http_code}\n' --interface $WEBCONFIG_INTERFACE --connect-timeout $TIMEOUT -m $TIMEOUT --output $CURL_RESPONSE -E $CURL_FILE_RESPONSE --header X-Midt-Mac-Address:\"$MAC\" --header X-Midt-Serial-Number:\"$SER_NUM\" --header X-Midt-Uuid:\"$UUID\" --header X-Midt-Transaction-Id:\"$UUID\" --header X-Midt-Partner-Id:\"$PartnerId\" $SERVER_URL"
+				else
+					 CURL_TOKEN="curl -w '%{http_code}\n' --connect-timeout $TIMEOUT -m $TIMEOUT --output $CURL_RESPONSE -E $CURL_FILE_RESPONSE --header X-Midt-Mac-Address:\"$MAC\" --header X-Midt-Serial-Number:\"$SER_NUM\" --header X-Midt-Uuid:\"$UUID\" --header X-Midt-Transaction-Id:\"$UUID\" --header X-Midt-Partner-Id:\"$PartnerId\" $SERVER_URL"
+				fi
+				result= eval $CURL_TOKEN > $HTTP_CODE
+				ret=$?
+				sleep 1
+				http_code=$(awk -F\" '{print $1}' $HTTP_CODE)
+				echo_t "WEBCONFIG: ret = $ret http_code: $http_code"
+				if [ $ret == 0 ] && [ $http_code == 200 ]; then
+					echo_t "WEBCONFIG: cURL success."
+					break;
+				elif [ $retry_count == 3 ]; then
+					echo_t "WEBCONFIG: Curl retry is reached to max 3 attempts, exiting the script."
+					break;
+				fi
+				echo_t "WEBCONFIG: Curl execution is failed, retry attempt: $retry_count."
+				retry_count=$((retry_count+1));
+			done
+			rm -f $HTTP_CODE
+			#Check for cURL success and its response file
+			if [ $http_code -eq 200 ] && [ -f $CURL_RESPONSE ]; then
+						echo_t "WEBCONFIG: cURL success"
+						echo_t "WEBCONFIG: File generated successfully"
+						printf "SUCCESS" 1>&3
+                        echo_t "WEBCONFIG: After update"
+			else
+				echo_t "WEBCONFIG: cURL request failed or it's response file not created "
+			fi
+		else
+			echo_t "WEBCONFIG: Failure configuration file missing"
+		fi
+}
+
+	runcURL

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/parodus_read_file.sh
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/parodus_read_file.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2019 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+#TODO add it common config file
+CURL_RESPONSE="/tmp/.cURLresponse"
+
+source /etc/device.properties
+
+if [ $DEVICE_TYPE == "broadband" ]; then
+
+        LOG_PATH="/rdklogs/logs"
+        CONSOLEFILE="$LOG_PATH/WEBCONFIGlog.txt.0"
+        exec 3>&1 4>&2 >>$CONSOLEFILE 2>&1
+fi
+
+echo_t()
+{
+        echo "`date +"%y%m%d-%T.%6N"` $1"
+}
+
+
+	echo_t "WEBCONFIG: read file script is called"
+
+	echo_t "WEBCONFIG: CURL_RESPONSE path is $CURL_RESPONSE"
+	if [ -f $CURL_RESPONSE ]; then
+		printf `cat $CURL_RESPONSE` 1>&3
+	else
+		printf "ERROR" 1>&3
+	fi

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/webpa_pre_setup.sh
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/parodus2ccsp/webpa_pre_setup.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2018 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+brctl addbr br0
+sleep 2
+ifconfig br0 192.168.101.3 up
+sleep 1
+
+### Added work around fix for dropbear process running ###
+PID_DROPBEAR=`pidof dropbear`
+
+if [ "$PID_DROPBEAR" = "" ]; then
+        echo "dropbear is not running"
+       /etc/utopia/service.d/service_sshd.sh sshd-restart
+else
+        echo "dropbear is running properly"
+fi

--- a/meta-rdk-broadband/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/meta-rdk-broadband/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -28,6 +28,10 @@ do_install:append() {
 
     ${@bb.utils.contains('DISTRO_FEATURES', 'OneWifi', 'echo "OneWiFiEnabled=true" >> ${D}${sysconfdir}/device.properties', '', d)}
     echo "MODEL_NUM=RPI_MOD" >> ${D}${sysconfdir}/device.properties
+    
+    echo "PARODUS_URL=tcp://127.0.0.1:6666" >> ${D}${sysconfdir}/device.properties
+    echo "WEBPA_CLIENT_URL=tcp://192.168.101.3:6667" >> ${D}${sysconfdir}/device.properties
+    echo "SERVERURL=https://webpa.rdkcentral.com:8080" >> ${D}${sysconfdir}/device.properties
 
     #For rfc Support
     sed -i '/DEVICE_TYPE/c\DEVICE_TYPE=broadband' ${D}${sysconfdir}/device.properties

--- a/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -13,8 +13,6 @@ RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "ccsp-adv-security"
 RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "ccsp-webui-jst"
 RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "ccsp-webui-php"
 
-RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "parodus"
-
 RDEPENDS_packagegroup-rdk-ccsp-broadband:remove = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'RDM', '', ' rdm-agent', d)} \
 "


### PR DESCRIPTION
Reason for change : Code Changes for the Webpa Implementation

Components required:
https://code.rdkcentral.com/r/plugins/gitiles/rdkb/components/generic/startParodus/+/refs/heads/rdk-next https://github.com/xmidt-org/parodus
https://github.com/xmidt-org/parodus2ccsp

RDKB components communicate with Pardous2ccsp which send the request to parodusStart(Will execute script parodusStartCheck.sh before starting parodusStart). start parodus communicates with platform hal and CM hal retrieving the modelnumber, serialnumber, firmware, etc. Once these data's are cross checked along the datamodel which are updated in the PSM database, request from parodus will go to webpa server using websocket. In the webpa server we have Rest API's to get/set datamodels and connected devices.

Start-parodus component to update the parodus.cmd, have integrated the start-parodus and webpa.service has been used

Test Procedure:
1.webpa.service should be up and running
2.parodus.service should be up and running
3.All the curl requests should work
4.We should be able to see the communication logs in both webpa and parodus logs 5.Curl request and response should also be successful

Test the webpa using below commands,
GET command
curl -H 'Authorization:Basic "Token" ' -i 'https://webpa.rdkcentral.com:9003/api/v2/device/mac:/config?names=Device.WiFi.SSID.10001.SSID'

SET command
curl -X PATCH https://webpa.rdkcentral.com:9003/api/v2/device/mac:/config -d '{"parameters": [ {"dataType": 0, "name": "Device.WiFi.SSID.10001.SSID", "value": "Testing"}]}' -H 'Authorization:Basic "token" '