### PR TITLE
ISSUE 92, RDKBACCL-1697: Port Triggering support in ARM system ready

### DIFF
--- a/recipes-extended/iptables/files/0001-add-port-triggering-support.patch
+++ b/recipes-extended/iptables/files/0001-add-port-triggering-support.patch
@@ -1,0 +1,390 @@
+Source: Backport from http://asuswrt-merlin.ng/
+Index: iptables-1.8.4/extensions/libipt_TRIGGER.c
+===================================================================
+--- /dev/null
++++ iptables-1.8.4/extensions/libipt_TRIGGER.c
+@@ -0,0 +1,347 @@
++/* Port-triggering target. 
++ *
++ * Copyright (C) 2003, CyberTAN Corporation
++ * All Rights Reserved.
++ */
++
++/* Shared library add-on to iptables to add port-trigger support. */
++
++#include <stdio.h>
++#include <string.h>
++#include <stdlib.h>
++#include <getopt.h>
++#include <xtables.h>
++#include <linux/netfilter_ipv4/ip_tables.h>
++#include <linux/netfilter_ipv4/ipt_TRIGGER.h>
++
++
++#define IPT_TRIGGER_USED    (1) << 0
++#define IPT_TRIGGER_MATCH_USED    (1) << 1
++#define IPT_TRIGGER_RELATE_USED    (1) << 2
++#define IPT_TRIGGER_DNAT_USED    (1) << 3
++#define IPT_TRIGGER_IN_USED    (1) << 4
++#define IPT_TRIGGER_OUT_USED    (1) << 5
++#define IPT_TRIGGER_PROTO_USED    (1) << 6
++
++static void
++parse_tcp_ports(const char *portstring, u_int16_t *ports)
++{
++        char *buffer;
++        char *cp;
++
++        buffer = strdup(portstring);
++        if ((cp = strchr(buffer, ':')) == NULL)
++                ports[0] = ports[1] = xtables_parse_port(buffer, "tcp");
++        else {
++                *cp = '\0';
++                cp++;
++
++                ports[0] = buffer[0] ? xtables_parse_port(buffer, "tcp") : 0;
++                ports[1] = cp[0] ? xtables_parse_port(cp, "tcp") : 0xFFFF;
++
++                if (ports[0] > ports[1])
++                        xtables_error(PARAMETER_PROBLEM,
++                                   "invalid portrange (min > max)");
++        }
++        free(buffer);
++}
++
++/* Function which prints out usage message. */
++
++static void TRIGGER_help(void)
++{
++	printf(
++               "TRIGGER  options:\n"
++                        " --trigger-type (dnat|in|out)\n"
++	         	"'\t\t Trigger type\n"
++                        " --trigger-proto proto\n"
++                        "\t\t Trigger protocol tcp|udp|all\n"
++                         " --trigger-match port[-port]\n"
++                         "\t\tTrigger destination port range\n"
++                         " --trigger-relate port[-port]\n"
++                         "\t\tPort range to map related destination port range to.\n\n"
++			  );
++}
++/* man 3 getopt structure */
++static struct option TRIGGER_opts[] = {
++	{ "trigger-type", 1, NULL, '1' },
++	{ "trigger-proto", 1, NULL, '2' },
++	{ "trigger-match", 1, NULL, '3' },
++	{ "trigger-relate", 1, NULL, '4' },
++	{ .name = NULL }
++
++};
++
++
++
++/* Parses ports */
++static int parse_ports(const char *arg, u_int16_t *ports)
++{
++	const char *dash;
++	int port;
++	ports[0] =  0;
++	ports[1] =  0;
++
++	dash = strchr(arg, ':');
++	if (dash == NULL) {
++            port = ( u_int16_t ) atoi(arg );
++	    if (port == 0 || port > 65535) {
++		    xtables_error(PARAMETER_PROBLEM, "Invalid Port  %d \n", port);
++		    return -1; /* not OK */
++	        }
++	    ports[0] =  port;
++	    ports[1] =  0;
++	}
++	else {
++		int portEnd;
++
++		port=strtol(arg, NULL, 10);
++		portEnd = ( u_int16_t ) atoi(dash + 1);
++		if (portEnd == 0 || portEnd > 65535 || ( portEnd < port ))
++		{
++			xtables_error(PARAMETER_PROBLEM, "Port range %d:%d is invalid\n", port, portEnd);
++		        return -1; /* not OK */
++		}
++		ports[0] = port;
++		ports[1] = portEnd;
++	}
++	return 1;
++}
++
++
++/* Function which parses command options; returns true if it
++   ate an option */
++
++static int 
++TRIGGER_parse(int c, char **argv, int invert, unsigned int *flags,
++      const void *entry,
++      struct xt_entry_target **target)
++{
++    struct ipt_trigger_info *info = (struct ipt_trigger_info *) (*target)->data;
++
++    if  ( info == NULL )
++    {
++          xtables_error(PARAMETER_PROBLEM, "NULL paramaeter (*target)->data specified" );
++	  return 0;
++    }
++    if  ( optarg == NULL )
++    {
++          xtables_error(PARAMETER_PROBLEM, "NULL paramaeter optarg specified" );
++	  return 0;
++    }
++
++    /* Parse argument number 1, 2,3, 4 */
++	switch (c) {
++	case '1':
++	        {
++		if (!strncasecmp(optarg, "dnat",3))
++                {
++			info->type = IPT_TRIGGER_DNAT;
++		         *flags |= IPT_TRIGGER_DNAT_USED;
++                }
++		else if (!strncasecmp(optarg, "in",2))
++                {
++			info->type = IPT_TRIGGER_IN;
++		         *flags |= IPT_TRIGGER_IN_USED;
++                }
++		else if (!strncasecmp(optarg, "out",3))
++                {
++			info->type = IPT_TRIGGER_OUT;
++		         *flags |= IPT_TRIGGER_OUT_USED;
++                }
++		else
++                {
++			xtables_error(PARAMETER_PROBLEM, "unknown type trigger type specified");
++                        return 0;
++                }
++		return 1;
++	        }
++
++	case '2':
++	        {
++				if (!strncasecmp(optarg, "tcp",3))
++        		{
++					info->proto = IPPROTO_TCP;
++		         	*flags		|= IPT_TRIGGER_PROTO_USED;
++        		}
++				else if (!strncasecmp(optarg, "udp",3))
++        		{
++					info->proto	 = IPPROTO_UDP;
++		         	*flags		 |= IPT_TRIGGER_PROTO_USED;
++        		}
++				else if (!strncasecmp(optarg, "all",3))
++        		{
++					info->proto	 = IPT_TRIGGER_BOTH_PROTOCOLS;
++		         	*flags		 |= IPT_TRIGGER_PROTO_USED;
++        		}
++        		else if (!strncasecmp(optarg, "both",4))
++        		{
++					info->proto = IPT_TRIGGER_BOTH_PROTOCOLS;
++		        	 *flags		 |= IPT_TRIGGER_PROTO_USED;
++        		}
++				else
++        		{
++				xtables_error(PARAMETER_PROBLEM, "unknown protocol  specified");
++        		}
++				return 1;
++	        }
++
++	case '3':
++	        {
++		    if (invert) /* Operator NOT is not supported */
++		    {
++		        xtables_error(PARAMETER_PROBLEM, "Unexpected `!' after --trigger-match");
++                        return 0;
++
++                    }
++		    if (parse_ports(optarg, info->ports.mport))
++		    {
++		         *flags |= IPT_TRIGGER_MATCH_USED;
++			     *flags |= IPT_TRIGGER_USED;
++		         return 1;
++                     }
++                }
++
++	case '4':
++	        {
++		    	if (invert) /* Operator NOT is not supported */
++		    	{
++		            xtables_error(PARAMETER_PROBLEM, "Unexpected `!' after --trigger-relate");
++
++                 }
++		     	if (parse_ports(optarg, info->ports.rport))
++		     	{
++					*flags |= IPT_TRIGGER_RELATE_USED;
++					*flags |= IPT_TRIGGER_USED;
++		          return 1;
++             	}
++	        }
++
++	default:
++		   return 0; /* NOK */
++    }
++   return 0; /* NOK */
++}
++
++
++/* Prints out the targinfo. iptables -L  */
++static void TRIGGER_print(const void  *ip,
++      const struct xt_entry_target *target, int numeric)
++{
++	struct ipt_trigger_info *info = (struct ipt_trigger_info *)target->data;
++
++	printf(" TRIGGER ");
++	if (info->type == IPT_TRIGGER_DNAT)
++		printf("type:dnat ");
++	else if (info->type == IPT_TRIGGER_IN)
++		printf("type:in ");
++	else if (info->type == IPT_TRIGGER_OUT)
++		printf("type:out ");
++    if (info->type == IPT_TRIGGER_OUT)  /* only trigger-type out specifies other parameters */ 
++	{
++	if (info->proto == IPPROTO_TCP)
++		printf("tcp ");
++	else if (info->proto == IPPROTO_UDP)
++		printf("udp ");
++	else if (info->proto == IPT_TRIGGER_BOTH_PROTOCOLS)
++		printf("both ");
++	else
++	    printf("all ");
++
++	printf("match:%hu", info->ports.mport[0]);
++	if (info->ports.mport[1] > info->ports.mport[0])
++		printf("-%hu", info->ports.mport[1]);
++	printf(" ");
++
++	printf("relate:%hu", info->ports.rport[0]);
++	if (info->ports.rport[1] > info->ports.rport[0])
++		printf("-%hu", info->ports.rport[1]);
++	}
++	printf(" ");
++}
++/*
++*
++* last chance for sanity check. 
++* It's called when the user enter a new rule, right after arguments parsing is done.
++*  
++*/
++
++static void TRIGGER_final_check(unsigned int flags)
++{
++	if (flags & IPT_TRIGGER_OUT_USED)
++        {
++	   if (!(flags & IPT_TRIGGER_RELATE_USED))
++           {
++		xtables_error(PARAMETER_PROBLEM, "TRIGGER: You must specify trigger relate an parameter");
++           }
++	   if (!(flags & IPT_TRIGGER_MATCH_USED))
++           {
++		xtables_error(PARAMETER_PROBLEM, "TRIGGER: You must specify trigger match an parameter");
++           }
++	   if (!(flags & IPT_TRIGGER_OUT_USED))
++           {
++		xtables_error(PARAMETER_PROBLEM, "TRIGGER: You must specify trigger type an parameter");
++           }
++	   if (!(flags & IPT_TRIGGER_PROTO_USED))
++           {
++		xtables_error(PARAMETER_PROBLEM, "TRIGGER: You must specify trigger protocols an parameter");
++           }
++
++        }
++}
++
++/*
++* If we have a ruleset that we want to save, iptables provide the tool 'iptables-save' which dumps all your rules. It obviously needs your extension's help to dump proper rules.
++* This is done by calling this function.
++*
++* 
++*/
++
++
++static void TRIGGER_save(const void *ip, const struct xt_entry_target *target)
++{
++	struct ipt_trigger_info *info = (struct ipt_trigger_info *)target->data;
++
++	printf(" --trigger-proto ");
++	if (info->proto == IPPROTO_TCP)
++		printf("tcp ");
++	else if (info->proto == IPPROTO_UDP)
++		printf("udp ");
++	else if (info->proto == IPT_TRIGGER_BOTH_PROTOCOLS)
++		printf("both ");
++	else
++	    printf("all ");
++	printf(" --trigger-match %hu", info->ports.mport[0]);
++    if (info->ports.mport[1])
++        printf("-%hu", info->ports.mport[1]);
++	printf(" ");
++	printf(" --trigger-relate %hu", info->ports.rport[0]);
++    if (info->ports.rport[1])
++        printf("-%hu", info->ports.rport[1]);
++    printf(" ");
++}
++
++
++static struct xtables_target trigger_tg_reg = {
++        .name           = "TRIGGER",
++        .version        = XTABLES_VERSION,
++        .family         = NFPROTO_IPV4,
++        .size           = XT_ALIGN(sizeof(struct ipt_trigger_info)),
++        .userspacesize  = XT_ALIGN(sizeof(struct ipt_trigger_info)),
++        .help           = TRIGGER_help,
++        .parse          = TRIGGER_parse,
++		.final_check	= TRIGGER_final_check,
++        .print          = TRIGGER_print,
++        .save           = TRIGGER_save,
++        .extra_opts     = TRIGGER_opts,
++};
++
++void _init(void)
++{
++/*
++*
++*  This function is called when the module is loaded by iptables.
++*   man dlopen.
++*/
++	xtables_register_target(&trigger_tg_reg);
++}
+Index: iptables-1.8.4/include/linux/netfilter_ipv4/ipt_TRIGGER.h
+===================================================================
+--- /dev/null
++++ iptables-1.8.4/include/linux/netfilter_ipv4/ipt_TRIGGER.h
+@@ -0,0 +1,31 @@
++/* Port-triggering target. 
++ *
++ * Copyright (C) 2003, CyberTAN Corporation
++ * All Rights Reserved.
++ */
++
++/* Shared library add-on to iptables to add port-trigger support. */
++
++#ifndef _IPT_TRIGGER_H_target
++#define _IPT_TRIGGER_H_target
++#define IPT_TRIGGER_BOTH_PROTOCOLS 253  /* unassigned number */
++
++enum ipt_trigger_type
++{
++	IPT_TRIGGER_DNAT = 1,
++	IPT_TRIGGER_IN = 2,
++	IPT_TRIGGER_OUT = 3
++};
++
++struct ipt_trigger_ports {
++	u_int16_t mport[2];	/* Related destination port range */
++	u_int16_t rport[2];	/* Port range to map related destination port range to */
++};
++
++struct ipt_trigger_info {
++	enum ipt_trigger_type type;
++	u_int16_t proto;	/* Related protocol */
++	struct ipt_trigger_ports ports;
++};
++
++#endif /*_IPT_TRIGGER_H_target*/
+

--- a/recipes-extended/iptables/iptables_1.8.7.bbappend
+++ b/recipes-extended/iptables/iptables_1.8.7.bbappend
@@ -1,0 +1,5 @@
+RRECOMMENDS_${PN}_append += "kernel-module-xt-nat \
+                             kernel-module-ipt-trigger"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append = " file://0001-add-port-triggering-support.patch"

--- a/recipes-kernel/linux/files/0001-add-support-for-port-triggering.patch
+++ b/recipes-kernel/linux/files/0001-add-support-for-port-triggering.patch
@@ -1,0 +1,592 @@
+Source: Backport from http://asuswrt-merlin.ng/
+diff -Naur kernel-source.org/include/linux/netfilter_ipv4/ipt_TRIGGER.h kernel-source/include/linux/netfilter_ipv4/ipt_TRIGGER.h
+--- kernel-source.org/include/linux/netfilter_ipv4/ipt_TRIGGER.h	1970-01-01 00:00:00.000000000 +0000
++++ kernel-source/include/linux/netfilter_ipv4/ipt_TRIGGER.h	2022-07-02 11:28:18.703754924 +0000
+@@ -0,0 +1,35 @@
++/* Kernel module to match the port-ranges, trigger related port-ranges,
++ * and alters the destination to a local IP address.
++ *
++ * Copyright (C) 2003, CyberTAN Corporation
++ * All Rights Reserved.
++ *
++ * Description:
++ *   This is kernel module for port-triggering.
++ *
++ *   The module follows the Netfilter framework, called extended packet
++ *   matching modules.
++ */
++#ifndef _IPT_TRIGGER_H_target
++#define _IPT_TRIGGER_H_target
++#define IPT_TRIGGER_BOTH_PROTOCOLS 253  /* unassigned number */
++
++enum ipt_trigger_type
++{
++	IPT_TRIGGER_DNAT = 1,
++	IPT_TRIGGER_IN = 2,
++	IPT_TRIGGER_OUT = 3
++};
++
++struct ipt_trigger_ports {
++	u_int16_t mport[2];	/* Related destination port range */
++	u_int16_t rport[2];	/* Port range to map related destination port range to */
++};
++
++struct ipt_trigger_info {
++	enum ipt_trigger_type type;
++	u_int16_t proto;	/* Related protocol */
++	struct ipt_trigger_ports ports;
++};
++
++#endif /*_IPT_TRIGGER_H_target*/
+diff -Naur kernel-source.org/net/ipv4/netfilter/ipt_TRIGGER.c kernel-source/net/ipv4/netfilter/ipt_TRIGGER.c
+--- kernel-source.org/net/ipv4/netfilter/ipt_TRIGGER.c	1970-01-01 00:00:00.000000000 +0000
++++ kernel-source/net/ipv4/netfilter/ipt_TRIGGER.c	2022-07-02 13:05:48.185646732 +0000
+@@ -0,0 +1,519 @@
++/* Kernel module to match the port-ranges, trigger related port-ranges,
++* and alters the destination to a local IP address.
++*
++* Copyright (C) 2003, CyberTAN Corporation
++* All Rights Reserved.
++*
++* Description:
++*   This is kernel module for port-triggering.
++*
++*   The module follows the Netfilter framework, called extended packet
++*   matching modules.
++*/
++
++#include <linux/types.h>
++#include <linux/ip.h>
++#include <linux/tcp.h>
++#include <linux/module.h>
++#include <linux/netfilter.h>
++#include <linux/netdevice.h>
++#include <linux/if.h>
++#include <net/checksum.h>
++
++#include <linux/netfilter_ipv4.h>
++#include <linux/netfilter_ipv4/ip_tables.h>
++#include <net/netfilter/nf_conntrack.h>
++#include <net/netfilter/nf_conntrack_core.h>
++#include <net/netfilter/nf_conntrack_tuple.h>
++#include <net/netfilter/nf_nat.h>
++#include <linux/netfilter_ipv4/ipt_TRIGGER.h>
++#include <linux/timer.h>
++#include <net/protocol.h>
++#include <linux/inetdevice.h>
++
++/* Return pointer to first true entry, if any, or NULL.  A macro
++   required to allow inlining of cmpfn. */
++#define LIST_FIND(head, cmpfn, type, args...)           \
++   ({                                                      \
++           const struct list_head *__i, *__j = NULL;       \
++                                    \
++           list_for_each(__i, (head))                      \
++           if (cmpfn((const type)__i , ## args)) \
++           { \
++                  __j = __i;                     \
++                  break;                         \
++           }                                     \
++           (type)__j;                            \
++   })
++
++
++
++//#define TRIGGER_DEBUG
++#ifndef TRIGGER_DEBUG
++        #define KERN_LEVL  
++        #define DEBUGP( format, args...)
++        #define TRIGGER_TIMEOUT 120  /* 120 secs to wait for backward connection, when timeout - delete trigger */
++#else
++#define DEBUGP printk
++        #define KERN_LEVL KERN_CRIT 
++        #define DEBUG_BIG_TIMEOUT 600 /* 10 min */
++        #define TRIGGER_TIMEOUT DEBUG_BIG_TIMEOUT
++#endif
++
++MODULE_LICENSE("GPL");
++struct ipt_trigger {
++	struct list_head list;		/* Trigger list */
++	struct timer_list timeout;	/* Timer for list destroying */
++	__be32 srcip;	         	/* Outgoing source address */
++	__be32 dstip;	        	/* Outgoing destination address */
++	u_int16_t trig_proto;		/* Trigger protocol */
++	u_int16_t rproto;	     	/* Related protocol */
++	struct ipt_trigger_ports ports;	/* Trigger and related ports */
++	u_int8_t reply;		      	/* Confirm a reply connection */
++};
++
++static LIST_HEAD(trigger_list);
++
++
++static void trigger_refresh(struct ipt_trigger *trig, unsigned long extra_jiffies)
++{
++	DEBUGP( KERN_LEVL "%s: \n", __FUNCTION__);
++	NF_CT_ASSERT(trig);
++    spin_lock_bh(&nf_conntrack_lock);
++
++	/* Need del_timer for race avoidance (may already be dying). */
++	if (del_timer(&trig->timeout)) {
++		trig->timeout.expires = jiffies + extra_jiffies;
++		add_timer(&trig->timeout);
++	}
++
++    spin_unlock_bh(&nf_conntrack_lock);
++}
++
++static void __del_trigger(struct ipt_trigger *trig)
++{
++	DEBUGP( KERN_LEVL "%s: \n", __FUNCTION__);
++	NF_CT_ASSERT(trig);
++
++	 /* delete from 'trigger_list' */
++	list_del(&trig->list);
++	kfree(trig);
++}
++
++static void trigger_timeout(unsigned long ul_trig)
++{
++	struct ipt_trigger *trig= (void *) ul_trig;
++
++	DEBUGP( KERN_LEVL "trigger list %p timed out\n", trig);
++	spin_lock_bh(&nf_conntrack_lock);
++	__del_trigger(trig);
++    spin_unlock_bh(&nf_conntrack_lock);
++}
++
++static unsigned int
++add_new_trigger(struct ipt_trigger *trig)
++{
++	struct ipt_trigger *new;
++
++	DEBUGP( KERN_LEVL "!!!!!!!!!!!! %s !!!!!!!!!!!\n", __FUNCTION__);
++	spin_lock_bh(&nf_conntrack_lock);
++	new = (struct ipt_trigger *)
++		kmalloc(sizeof(struct ipt_trigger), GFP_ATOMIC);
++
++	if (!new) {
++		spin_unlock_bh(&nf_conntrack_lock);
++		DEBUGP( KERN_LEVL "%s: OOM allocating trigger list\n", __FUNCTION__);
++		return -ENOMEM;
++	}
++
++    memset(new, 0, sizeof(*trig));
++    memcpy(new, trig, sizeof(*trig));
++	INIT_LIST_HEAD(&new->list);
++
++	/* add to global table of trigger */
++	list_add(&trigger_list, &new->list);
++	/* add and start timer if required */
++	init_timer(&new->timeout);
++	new->timeout.data = (unsigned long)new;
++	new->timeout.function = trigger_timeout;
++	new->timeout.expires = jiffies + (TRIGGER_TIMEOUT * HZ);
++	add_timer(&new->timeout);
++		   
++    spin_unlock_bh(&nf_conntrack_lock);
++
++    return 0;
++}
++/* Find a match for trigger-type=out, i.e match on trigger private ports */
++static inline int trigger_out_matched(const struct ipt_trigger *i,
++	const u_int16_t proto, const u_int16_t dport)
++{
++    u_int16_t tproto = i->trig_proto;
++    DEBUGP( KERN_LEVL "%s: Packet proto= %d, dport=%d.\n", __FUNCTION__,  proto, dport); 
++    DEBUGP( KERN_LEVL "%s: Trigger address =%p, trigger_protocol= %d, SRC_IP=%pI4 DST_IP=%pI4 mport[0..1]=%d, %d.\n", __FUNCTION__, 
++	    i, i->trig_proto, &i->srcip, &i->dstip, i->ports.mport[0], i->ports.mport[1]); 
++
++
++    /*
++       Return OK if packet port belons to trigger related range  (public)
++       And protocol is indeed one of specified
++    */
++    if  (tproto != IPT_TRIGGER_BOTH_PROTOCOLS)  
++    {
++        /* Test exact protocol */
++        if  (tproto != proto) 
++        {
++             return 0; /* not matched */
++        }
++
++    }
++    if ( (i->ports.mport[0] <= dport)  && (i->ports.mport[1] >= dport))
++    {
++        DEBUGP( KERN_LEVL "%s: MATCHED trigger, Proto= %d, rport[0..1]=%d, %d.\n", __FUNCTION__, 
++	    i->trig_proto, i->ports.mport[0], i->ports.mport[1]); 
++        return 1; /* ports in range,  match */
++    }
++    else
++    {
++        return 0; /* not matched */
++    }
++        
++}
++
++/*
++  This function creates trigger when packet traverse from 
++  internal LAN to WAN destination 
++  the packet is NATed, so nat hash is created
++*/
++
++static unsigned int
++trigger_out(struct sk_buff *skb , 
++			const void *targinfo
++			) 
++{
++
++
++	const struct ipt_trigger_info *info = targinfo;
++	struct ipt_trigger trig, *found;
++	const struct iphdr *iph = ip_hdr(skb);
++	struct tcphdr *tcph = (void *)iph + iph->ihl*4;     /* Might be TCP, UDP */
++
++	DEBUGP( KERN_LEVL "############# %s ############\n", __FUNCTION__);
++	/* Check if the trigger range has already existed in 'trigger_list'. */
++	found = LIST_FIND(&trigger_list, trigger_out_matched,
++			struct ipt_trigger *, iph->protocol, ntohs(tcph->dest));
++
++	if (found) {
++		/* Yeah, it exists. We need to update(delay) the destroying timer. */
++		trigger_refresh(found, TRIGGER_TIMEOUT * HZ);
++		/* In order to allow multiple hosts use the same port range( and trigger), we update
++		   the 'saddr' after the reply connection was made ( see trigger_in() ) */
++		if (found->reply)
++			found->srcip = iph->saddr;
++	}
++	else {
++		/* Create new trigger */
++		memset(&trig, 0, sizeof(trig));
++		trig.srcip = iph->saddr;  /* Stores originating IP */
++		trig.dstip = iph->daddr;  /* Stores destination IP */
++		trig.rproto = iph->protocol;
++		trig.trig_proto = info->proto;
++        DEBUGP ("TRIGGER OUT -protocol %d\n", info->proto);
++		memcpy(&trig.ports, &info->ports, sizeof(struct ipt_trigger_ports));
++	        if (trig.ports.rport[1] == 0)
++                   trig.ports.rport[1] = trig.ports.rport[0];
++	        if (trig.ports.mport[1] == 0)
++                   trig.ports.mport[1] = trig.ports.mport[0];
++		add_new_trigger(&trig); /* Add the new 'trig' to list 'trigger_list'. */
++	}
++
++    return XT_CONTINUE;    /* Proceed to  other checks, ex parential control, ... */
++}
++
++/* Find a match for trigger-type=in and dnat, i.e match on trigger public ports */
++static inline int trigger_in_matched(const struct ipt_trigger *i,
++	const u_int16_t proto, const u_int16_t dport)
++{
++    u_int16_t tproto = i->trig_proto;
++
++    DEBUGP( KERN_LEVL "%s: Packet proto= %d, dport=%d.\n", __FUNCTION__,  proto, dport); 
++    DEBUGP( KERN_LEVL "%s: Trigger address =%p, trigger_protocol= %d, mport[0..1]=%d, %d.\n", __FUNCTION__, 
++	    i, i->trig_proto, i->ports.mport[0], i->ports.mport[1]); 
++
++    /*
++       Return OK if packet port belons to trigger related range  (public)
++       And protocol is indeed one of specified
++    */
++    if  (tproto != IPT_TRIGGER_BOTH_PROTOCOLS)  
++    {
++        /* Test exact protocol */
++        if  (tproto != proto) 
++        {
++             return 0; /* not matched */
++        }
++    }
++
++    if ( (i->ports.rport[0] <= dport)  && (i->ports.rport[1] >= dport))
++    {
++        DEBUGP( KERN_LEVL "%s: MATCHED trigger, Proto= %d, rport[0..1]=%d, %d.\n", __FUNCTION__, 
++	    i->trig_proto, i->ports.rport[0], i->ports.rport[1]); 
++        return 1; /* ports in range,  match */
++    }
++    else
++    {
++        return 0; /* not matched */
++    }
++}
++/*
++  This function proceed packets which where changed by dnat function and allows them in forward chain 
++  
++*/
++
++static unsigned int
++trigger_in(struct sk_buff *skb)
++{
++    struct ipt_trigger *found;
++    const struct iphdr *iph = ip_hdr(skb);
++
++    struct tcphdr *tcph = (void *)iph + iph->ihl*4;	/* Might be TCP, UDP */
++    /* Check if the trigger for this range was already created and inserted into the 'trigger_list'. */
++    DEBUGP( KERN_LEVL "TRIGGER_IN - CHECK range: packet src->%pI4"
++                               "  packet dst->%pI4" "\n" ,
++                              &iph->saddr,
++                              &iph->daddr
++                               );
++	
++    found = LIST_FIND(&trigger_list, trigger_in_matched,
++	                  struct ipt_trigger *, iph->protocol, ntohs(tcph->dest));
++    if (found)
++    {
++
++        DEBUGP( KERN_LEVL "TRIGGER_IN: TRIGGER FOUND packet src->%pI4"
++               " packet dst->%pI4 \n" ,
++               &iph->saddr,
++               &iph->daddr
++              );
++
++        /* Yeah, it exists. We need to update(delay) the destroying timer. */
++        trigger_refresh(found, TRIGGER_TIMEOUT * HZ);
++        DEBUGP( KERN_LEVL KERN_INFO "TRIGGER_IN: refresh trigger \n "  );
++        /* Accept it, or the incoming packet will be 
++                dropped in the FORWARD chain */
++        return NF_ACCEPT;    
++    }
++
++    return XT_CONTINUE;	/* the match was done but no trigger exist  */
++}
++
++static void xt_nat_convert_range(struct nf_nat_range *dst,
++				 const struct nf_nat_ipv4_range *src)
++{
++	memset(&dst->min_addr, 0, sizeof(dst->min_addr));
++	memset(&dst->max_addr, 0, sizeof(dst->max_addr));
++
++	dst->flags	 = src->flags;
++	dst->min_addr.ip = src->min_ip;
++	dst->max_addr.ip = src->max_ip;
++	dst->min_proto	 = src->min;
++	dst->max_proto	 = src->max;
++}
++
++/*
++  This function translates received from WAN packet  dest.IP to IP of the trigger invoker
++  (trigger type 'out' )
++  ??It needs to have conntrack info in order to associate incoming packet with previouslu made
++  connectin from LAN to WAN
++*/
++
++static unsigned int
++trigger_dnat(struct sk_buff *skb, int hooknum)
++{
++	struct ipt_trigger *found;
++	struct iphdr *iph = ip_hdr(skb);
++	struct tcphdr *tcph = (void *)iph + iph->ihl*4;     /* Might be TCP, UDP */
++    struct nf_conn *ct;
++	enum ip_conntrack_info ctinfo;
++	struct nf_nat_ipv4_multi_range_compat newrange;
++    struct nf_nat_range range;
++
++	DEBUGP( KERN_LEVL "####Starting  %s ############\n", __FUNCTION__);
++    DEBUGP( KERN_LEVL "TRIGGER_DNAT: Protocol ->%s  SRC_IP->%pI4"
++                               " DST IP->%pI4 \n" ,
++                               (iph->protocol == IPPROTO_TCP) ? "TCP" : "UDP",
++                               &iph->saddr,
++                               &iph->daddr
++                               );
++	NF_CT_ASSERT(hooknum == NF_INET_PRE_ROUTING);
++	/* Check if the trigger-ed range has already existed in 'trigger_list'. */
++	found = LIST_FIND(&trigger_list, trigger_in_matched,
++			struct ipt_trigger *, iph->protocol, ntohs(tcph->dest));
++
++	if (!found || !found->srcip)
++		return XT_CONTINUE;    /* We don't block any packet, continue to scan rules table. */
++
++	DEBUGP( KERN_LEVL "##### FOUND ### %s ############\n", __FUNCTION__);
++	found->reply = 1;   /* Indicate that this match means a packet from related connection. */
++
++	//ct = nf_conntrack_get(skb->nfct);
++	ct = nf_ct_get(skb, &ctinfo);
++	NF_CT_ASSERT(ct && (ctinfo == IP_CT_NEW));
++
++	DEBUGP( KERN_LEVL "%s: Got ready to dnat -foud proper trigger and doing address replacement ", __FUNCTION__);
++	nf_ct_dump_tuple(&ct->tuplehash[IP_CT_DIR_ORIGINAL].tuple);
++
++    /* Alter the destination of imcoming packet. */
++    newrange.rangesize = 1;
++	newrange.range[0].flags = NF_NAT_RANGE_MAP_IPS;
++	newrange.range[0].min_ip = found->srcip;
++	newrange.range[0].max_ip = found->srcip;
++	newrange.range[0].min.all = 0;
++	newrange.range[0].min.all = 0;
++
++	xt_nat_convert_range(&range, &newrange.range[0]);
++
++        /* 
++	*  We call here to create the nat processor  that will replace packet source address 
++	*  to the address of the port forwarder requestor. 
++	*/
++	/* The nat  table is slightly different from the `filter' table,
++	in that only the first packet of a new connection will traverse the table:
++	the result of this traversal is then applied to all future packets in the same connection.
++	http://www.netfilter.org/documentation/HOWTO//netfilter-hacking-HOWTO-3.html#ss3.3
++        In test on aborted udp client, repeated udp connection was not established due to
++        Conntrack Error : Protocol Error Detected for packet
++        evidently  caused by UDP server not sending a single reply, so protocol state is not defined 
++
++        */
++	
++	/* Alter the destination of incoming packet. */
++	return nf_nat_setup_info(ct, &range, NF_NAT_MANIP_DST);
++}
++
++
++static unsigned int
++trigger_target(struct sk_buff *skb, const struct xt_action_param *par)
++{
++	unsigned int hooknum=par->hooknum;
++	const struct ipt_trigger_info *info =  par->targinfo ;
++	const struct iphdr *iph = ip_hdr(skb);
++    
++
++
++
++    /* DEBUGP( KERN_LEVL "%s: type = %s\n", __FUNCTION__, 
++	    (info->type == IPT_TRIGGER_DNAT) ? "dnat" :
++	    (info->type == IPT_TRIGGER_IN) ? "in" : "out"); */
++
++   /* The Port-trigger only supports TCP and UDP. */
++    if ((iph->protocol != IPPROTO_TCP) && (iph->protocol != IPPROTO_UDP))
++	return XT_CONTINUE;
++
++	if (info->type == IPT_TRIGGER_OUT)
++		return trigger_out(skb, par->targinfo);
++	else if (info->type == IPT_TRIGGER_IN)
++		return trigger_in(skb );
++	else if (info->type == IPT_TRIGGER_DNAT)
++		return trigger_dnat(skb, hooknum);
++	return XT_CONTINUE;
++}
++
++static int trigger_check(const struct xt_tgchk_param *par )
++{
++	const struct ipt_trigger_info *info = par->targinfo;
++	unsigned int hook_mask = par->hook_mask;
++    /* Original version requires nat table, but  there is no need to do any nat related function in this
++       char * tablename=par->table;
++	   hook so mangle table is good
++	if ((strcmp(tablename, "mangle") == 0)) {
++		printk("trigger_check: bad table `%s'.\n", tablename);
++		return -EINVAL;
++	}
++	*/
++	if (hook_mask & ~((1 << NF_INET_PRE_ROUTING) | (1 << NF_INET_FORWARD))) {
++		printk("trigger_check: bad hooks %x.\n", hook_mask);
++		return -EINVAL;
++	}
++    if (info->type == IPT_TRIGGER_OUT)  /* only trigger-type out specifies protocol and other parameters */ 
++	{
++	switch (info->proto)
++	{
++		case IPPROTO_TCP :
++    	case IPPROTO_UDP :
++    	case IPT_TRIGGER_BOTH_PROTOCOLS :
++		{
++    		DEBUGP( KERN_LEVL "trigger_check: valid protocol %d.\n", info->proto);
++        	break;
++    	}            
++    	default :
++    	{
++			printk("trigger_check: ERROR:BAD protocol %d.\n", info->proto);
++			return -EINVAL;
++		}
++	}
++	}
++	if (info->type == IPT_TRIGGER_OUT) {
++	    if (!info->ports.mport[0] || !info->ports.rport[0]) {
++		printk("trigger_check: Try 'iptables -j TRIGGER -h' for help.\n");
++		return -EINVAL;
++	    }
++	}
++
++       /* Empty the 'trigger_list' */
++       #if 0
++	list_for_each_safe(cur_item, tmp_item, &trigger_list)
++        {
++	      struct ipt_trigger *trig = (void *)cur_item;
++
++	      DEBUGP( KERN_LEVL "%s: list_for_each_safe(): %p.\n", __FUNCTION__, trig);
++	      del_timer(&trig->timeout);
++	      __del_trigger(trig);
++	}
++        #endif
++
++        return 0;
++}
++
++static struct xt_target redirect_reg __read_mostly = {
++	.name           = "TRIGGER",
++	.family         = NFPROTO_IPV4,
++	.target         = trigger_target,
++	.targetsize     = sizeof(struct ipt_trigger_info),
++	.hooks		= (1 << NF_INET_PRE_ROUTING) | (1 << NF_INET_FORWARD),
++	.checkentry     = trigger_check,
++	.me             = THIS_MODULE,
++};
++
++static int __init porttrigger_init(void)
++{
++		return xt_register_target(&redirect_reg);
++}
++
++static void __exit porttrigger_exit(void)
++{
++		xt_unregister_target(&redirect_reg);
++}
++
++module_init(porttrigger_init);
++module_exit(porttrigger_exit);
++/*
++
++EXT_IF="erouter0"
++INT_IF="rndbr1"
++iptables  --policy FORWARD ACCEPT
++iptables -t nat -I PREROUTING 1 -i $EXT_IF -p tcp --dport 9881:9889 -j LOG --log-level=4
++iptables -t nat -I PREROUTING 2 -i $EXT_IF -p tcp --dport 9881:9889 -j TRIGGER --trigger-type dnat --trigger-proto all --trigger-match 6881:6889 --trigger-relate 9881:9889
++#NEXT LINE - DEBUG
++#iptables -t nat -I PREROUTING 1 -i $INT_IF -p tcp --dport 9881:9889 -j TRIGGER --trigger-type dnat --trigger-proto all --trigger-match 6881:6889 --trigger-relate 9881:9889
++# IP TUROTIAL says it may be maid in mangle table
++iptables  -I FORWARD 1 -i $EXT_IF -p tcp --dport 9881:9889 -j LOG --log-level 4
++iptables  -I FORWARD 2 -i $EXT_IF -p tcp --dport 9881:9889 -j TRIGGER --trigger-type in --trigger-proto all --trigger-match 6881:6889 --trigger-relate 9881:9889
++#next line is openwrt http://www.elbeno.com/openwrt/openwrt_porttrigger.html
++# http://svn.dd-wrt.com/browser/src/linux/xscale/linux-2.6.24/net/ipv4/netfilter/ipt_TRIGGER.c
++#iptables -I FORWARD 1 -p tcp --dport 6881:6889 -j TRIGGER --trigger-type in --trigger-proto all --trigger-match 6881:6889 --trigger-relate 9881:9889
++iptables -t mangle -I PREROUTING 1 -i $INT_IF -p tcp --dport 6881:6889 -j TRIGGER --trigger-type out --trigger-proto all --trigger-match 6881:6889 --trigger-relate 9881:9889
++
++*/
++/* add nat rule  to chain MINIUPNPD/PREROUTING
++ * iptables -t nat -A MINIUPNPD -p proto --dport eport -j DNAT --to iaddr:iport
++  add forward rule to chain MINIUPNPD
++ $IPTABLES -t filter -A FORWARD -i $EXTIF ! -o $EXTIF -j MINIUPNPD
++* */
+diff -Naur kernel-source.org/net/ipv4/netfilter/Kconfig kernel-source/net/ipv4/netfilter/Kconfig
+--- kernel-source.org/net/ipv4/netfilter/Kconfig	2022-07-01 12:02:15.529944943 +0000
++++ kernel-source/net/ipv4/netfilter/Kconfig	2022-07-02 11:33:58.072560605 +0000
+@@ -194,6 +194,14 @@
+ 
+ 	  To compile it as a module, choose M here.  If unsure, say N.
+ 
++config IP_NF_TARGET_TRIGGER
++        tristate "TRIGGER target support"
++        depends on NF_NAT
++        default m if NETFILTER_ADVANCED=n
++        help
++          Implemenets  port trigger action which occur on any matching packet.
++          To compile it as a module, choose M here.  If unsure, say N.
++
+ config IP_NF_TARGET_SYNPROXY
+ 	tristate "SYNPROXY target support"
+ 	depends on NF_CONNTRACK && NETFILTER_ADVANCED
+diff -Naur kernel-source.org/net/ipv4/netfilter/Makefile kernel-source/net/ipv4/netfilter/Makefile
+--- kernel-source.org/net/ipv4/netfilter/Makefile	2022-07-01 12:02:15.529944943 +0000
++++ kernel-source/net/ipv4/netfilter/Makefile	2022-07-02 11:38:02.933142415 +0000
+@@ -50,6 +50,7 @@
+ obj-$(CONFIG_IP_NF_TARGET_ECN) += ipt_ECN.o
+ obj-$(CONFIG_IP_NF_TARGET_REJECT) += ipt_REJECT.o
+ obj-$(CONFIG_IP_NF_TARGET_SYNPROXY) += ipt_SYNPROXY.o
++obj-$(CONFIG_IP_NF_TARGET_TRIGGER) += ipt_TRIGGER.o
+ 
+ # generic ARP tables
+ obj-$(CONFIG_IP_NF_ARPTABLES) += arp_tables.o

--- a/recipes-kernel/linux/files/0002_arm_port_triggering.patch
+++ b/recipes-kernel/linux/files/0002_arm_port_triggering.patch
@@ -1,0 +1,147 @@
+diff --git a/include/linux/netfilter/x_tables.h b/include/linux/netfilter/x_tables.h
+index 5897f3dbaf7c..2fe752b7020b 100644
+--- a/include/linux/netfilter/x_tables.h
++++ b/include/linux/netfilter/x_tables.h
+@@ -36,6 +36,7 @@ struct xt_action_param {
+ 		const void *matchinfo, *targinfo;
+ 	};
+ 	const struct nf_hook_state *state;
++	unsigned int    hooknum;
+ 	unsigned int thoff;
+ 	u16 fragoff;
+ 	bool hotdrop;
+diff --git a/include/linux/timer.h b/include/linux/timer.h
+index e78521bce565..23d666766b13 100644
+--- a/include/linux/timer.h
++++ b/include/linux/timer.h
+@@ -15,6 +15,7 @@ struct timer_list {
+ 	 */
+ 	struct hlist_node	entry;
+ 	unsigned long		expires;
++	unsigned long            data;
+ 	void			(*function)(struct timer_list *);
+ 	u32			flags;
+ 
+diff --git a/include/net/netfilter/nf_conntrack.h b/include/net/netfilter/nf_conntrack.h
+index 39541ab912a1..30e5471c3812 100644
+--- a/include/net/netfilter/nf_conntrack.h
++++ b/include/net/netfilter/nf_conntrack.h
+@@ -24,6 +24,8 @@
+ 
+ #include <net/netfilter/nf_conntrack_tuple.h>
+ 
++#define NF_CT_ASSERT(x)
++
+ struct nf_ct_udp {
+ 	unsigned long	stream_ts;
+ };
+diff --git a/net/ipv4/netfilter/ipt_TRIGGER.c b/net/ipv4/netfilter/ipt_TRIGGER.c
+index 6c43f023fc67..9a9d1f3a7410 100644
+--- a/net/ipv4/netfilter/ipt_TRIGGER.c
++++ b/net/ipv4/netfilter/ipt_TRIGGER.c
+@@ -79,7 +79,7 @@ static void trigger_refresh(struct ipt_trigger *trig, unsigned long extra_jiffie
+ {
+ 	DEBUGP( KERN_LEVL "%s: \n", __FUNCTION__);
+ 	NF_CT_ASSERT(trig);
+-    spin_lock_bh(&nf_conntrack_lock);
++	spin_lock_bh(&nf_conntrack_expect_lock);
+ 
+ 	/* Need del_timer for race avoidance (may already be dying). */
+ 	if (del_timer(&trig->timeout)) {
+@@ -87,7 +87,7 @@ static void trigger_refresh(struct ipt_trigger *trig, unsigned long extra_jiffie
+ 		add_timer(&trig->timeout);
+ 	}
+ 
+-    spin_unlock_bh(&nf_conntrack_lock);
++	spin_unlock_bh(&nf_conntrack_expect_lock);
+ }
+ 
+ static void __del_trigger(struct ipt_trigger *trig)
+@@ -100,14 +100,14 @@ static void __del_trigger(struct ipt_trigger *trig)
+ 	kfree(trig);
+ }
+ 
+-static void trigger_timeout(unsigned long ul_trig)
++static void trigger_timeout(struct timer_list *t)
+ {
+-	struct ipt_trigger *trig= (void *) ul_trig;
++	struct ipt_trigger *trig= from_timer(trig, t,timeout);
+ 
+ 	DEBUGP( KERN_LEVL "trigger list %p timed out\n", trig);
+-	spin_lock_bh(&nf_conntrack_lock);
++	spin_lock_bh(&nf_conntrack_expect_lock);
+ 	__del_trigger(trig);
+-    spin_unlock_bh(&nf_conntrack_lock);
++	spin_unlock_bh(&nf_conntrack_expect_lock);
+ }
+ 
+ static unsigned int
+@@ -116,12 +116,12 @@ add_new_trigger(struct ipt_trigger *trig)
+ 	struct ipt_trigger *new;
+ 
+ 	DEBUGP( KERN_LEVL "!!!!!!!!!!!! %s !!!!!!!!!!!\n", __FUNCTION__);
+-	spin_lock_bh(&nf_conntrack_lock);
++	spin_lock_bh(&nf_conntrack_expect_lock);
+ 	new = (struct ipt_trigger *)
+ 		kmalloc(sizeof(struct ipt_trigger), GFP_ATOMIC);
+ 
+ 	if (!new) {
+-		spin_unlock_bh(&nf_conntrack_lock);
++		spin_unlock_bh(&nf_conntrack_expect_lock);
+ 		DEBUGP( KERN_LEVL "%s: OOM allocating trigger list\n", __FUNCTION__);
+ 		return -ENOMEM;
+ 	}
+@@ -133,13 +133,13 @@ add_new_trigger(struct ipt_trigger *trig)
+ 	/* add to global table of trigger */
+ 	list_add(&trigger_list, &new->list);
+ 	/* add and start timer if required */
+-	init_timer(&new->timeout);
++	//init_timer(&new->timeout);
+ 	new->timeout.data = (unsigned long)new;
+ 	new->timeout.function = trigger_timeout;
+ 	new->timeout.expires = jiffies + (TRIGGER_TIMEOUT * HZ);
+-	add_timer(&new->timeout);
++	timer_setup(&new->timeout,trigger_timeout,0);
+ 		   
+-    spin_unlock_bh(&nf_conntrack_lock);
++    spin_unlock_bh(&nf_conntrack_expect_lock);
+ 
+     return 0;
+ }
+@@ -304,8 +304,8 @@ trigger_in(struct sk_buff *skb)
+     return XT_CONTINUE;	/* the match was done but no trigger exist  */
+ }
+ 
+-static void xt_nat_convert_range(struct nf_nat_range *dst,
+-				 const struct nf_nat_ipv4_range *src)
++static void xt_nat_convert_range(struct nf_nat_range2 *dst,
++ 				 const struct nf_nat_ipv4_range *src)
+ {
+ 	memset(&dst->min_addr, 0, sizeof(dst->min_addr));
+ 	memset(&dst->max_addr, 0, sizeof(dst->max_addr));
+@@ -334,6 +334,7 @@ trigger_dnat(struct sk_buff *skb, int hooknum)
+ 	enum ip_conntrack_info ctinfo;
+ 	struct nf_nat_ipv4_multi_range_compat newrange;
+     struct nf_nat_range range;
++    struct nf_nat_range2 range_info;
+ 
+ 	DEBUGP( KERN_LEVL "####Starting  %s ############\n", __FUNCTION__);
+     DEBUGP( KERN_LEVL "TRIGGER_DNAT: Protocol ->%s  SRC_IP->%pI4"
+@@ -368,7 +369,7 @@ trigger_dnat(struct sk_buff *skb, int hooknum)
+ 	newrange.range[0].min.all = 0;
+ 	newrange.range[0].min.all = 0;
+ 
+-	xt_nat_convert_range(&range, &newrange.range[0]);
++	xt_nat_convert_range(&range_info, &newrange.range[0]);
+ 
+         /* 
+ 	*  We call here to create the nat processor  that will replace packet source address 
+@@ -385,7 +386,7 @@ trigger_dnat(struct sk_buff *skb, int hooknum)
+         */
+ 	
+ 	/* Alter the destination of incoming packet. */
+-	return nf_nat_setup_info(ct, &range, NF_NAT_MANIP_DST);
++	return nf_nat_setup_info(ct, &range_info, NF_NAT_MANIP_DST);
+ }
+ 
+ 

--- a/recipes-kernel/linux/files/0002_arm_port_triggering.patch
+++ b/recipes-kernel/linux/files/0002_arm_port_triggering.patch
@@ -1,3 +1,4 @@
+Source: RDKM (aishwarya_natarajan2@comcast.com)
 diff --git a/include/linux/netfilter/x_tables.h b/include/linux/netfilter/x_tables.h
 index 5897f3dbaf7c..2fe752b7020b 100644
 --- a/include/linux/netfilter/x_tables.h

--- a/recipes-kernel/linux/linux-yocto_5.15.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.15.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
 SRCREV_machine:armefi64 = "5a4667da1ebc1750b1ddaaf93a1f3f98634360e3"
 LINUX_VERSION = "5.15.162"
 
@@ -11,6 +13,8 @@ SRC_URI:append:armefi64 = " \
     file://02_dpaa2_add_more_10G_modes.patch \
     file://03_rk3568-pcie-phy-backports.patch \
     "
+SRC_URI:append = "file://0001-add-support-for-port-triggering.patch \
+                  file://0002_arm_port_triggering.patch"
 
 RDKBFILESPATHS := "${THISDIR}/rdkb:"
 FILESEXTRAPATHS:prepend:broadband = "${RDKBFILESPATHS}"


### PR DESCRIPTION
Reason for change: Bring up of port triggering support in ARM system ready builds 
Test procedure: To validate and demonstrate the functionality of Port Triggering on the router by ensuring that incoming traffic on specified target ports (FTP – 21, UDP – 2399, TCP – 5001) is allowed only after an outgoing trigger packet is initiated on port 443 from the LAN client.
By default Port triggering will be disabled in the ARM. We can enable using two methods .One is through DM and other way is through UI.
Detailed test steps attached in wiki https://wiki.rdkcentral.com/spaces/RDK/pages/306415229/Port+Triggering+in+RPI