### PR TITLE
Fix compiler errors when DEBUG_BUILD=1

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -37,6 +37,13 @@ SRC_URI:append = " file://0003-meta-rdk-bsp-arm-only-remove-pre-and-post-start-c
 SRC_URI:append = " file://0004-systemd-ccsp-eth-agent-sd-notify.patch"
 SRC_URI:append = " file://0005-systemd-rdk-wan-manager-eth-agent.patch"
 
+# Fix compile errors when debug symbol generation / compiler flags
+# are enabled in the BitBake EnvironmentFile
+SRC_URI:append = " file://0006-util_api-fix-compile-error-under-debug-build.patch \
+                   file://0007-util_api-al_pki-resolve-uninitialized-variable-compi.patch \
+                   file://0008-util_api-al_pkcs12-fix-uninitialized-variable-error.patch \
+"
+
 do_configure:prepend:aarch64() {
 	sed -e '/len/ s/^\/*/\/\//' -i ${S}/source/ccsp/components/common/DataModel/dml/components/DslhObjRecord/dslh_objro_access.c
 }

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -42,6 +42,7 @@ SRC_URI:append = " file://0005-systemd-rdk-wan-manager-eth-agent.patch"
 SRC_URI:append = " file://0006-util_api-fix-compile-error-under-debug-build.patch \
                    file://0007-util_api-al_pki-resolve-uninitialized-variable-compi.patch \
                    file://0008-util_api-al_pkcs12-fix-uninitialized-variable-error.patch \
+                   file://0009-cosa-assert-AnscCopyString-can-not-be-called-same.patch \
 "
 
 do_configure:prepend:aarch64() {

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0006-util_api-fix-compile-error-under-debug-build.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0006-util_api-fix-compile-error-under-debug-build.patch
@@ -1,0 +1,23 @@
+From 26ce65b040c7281992dadac353d5cd8102e2fd9a Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Wed, 22 Apr 2026 00:18:25 +0000
+Subject: [PATCH] util_api: fix compile error under debug build
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+---
+ source/util_api/ccsp_msg_bus/ccsp_base_api.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/util_api/ccsp_msg_bus/ccsp_base_api.c b/source/util_api/ccsp_msg_bus/ccsp_base_api.c
+index 56e414a..3ab2e9c 100644
+--- a/source/util_api/ccsp_msg_bus/ccsp_base_api.c
++++ b/source/util_api/ccsp_msg_bus/ccsp_base_api.c
+@@ -1503,7 +1503,7 @@ int CcspBaseIf_registerCapabilities_rbus(
+     int i = 0;
+     int failedIndex = 0;
+     int ret = CCSP_SUCCESS;
+-    int err;
++    int err = RBUS_ERROR_NOT_INITIALIZED;
+     int isSubCacheLoaded = 0;
+     CCSP_MESSAGE_BUS_INFO *bus_info = (CCSP_MESSAGE_BUS_INFO *)bus_handle;
+ 

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0007-util_api-al_pki-resolve-uninitialized-variable-compi.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0007-util_api-al_pki-resolve-uninitialized-variable-compi.patch
@@ -1,0 +1,62 @@
+From a94e45d7efbf37427cfeddd630e03a9104f4a722 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Wed, 22 Apr 2026 00:25:39 +0000
+Subject: [PATCH] util_api: al_pki: resolve uninitialized variable compile
+ errors
+
+When debug related options are enabled in the BitBake environment,
+the following compile error may occur:
+
+smartcard_sample_entity.c: In function 'SmartCardSignData':
+smartcard_sample_entity.c:143:37: error: 'retStatus' may be used
+	uninitialized in this function [-Werror=maybe-uninitialized]
+
+pki_entity_base.c: In function 'PKIEntitySignData':
+pki_entity_base.c:1974:16: error: 'retStatus' may be used
+	uninitialized in this function [-Werror=maybe-uninitialized]
+
+pki_entity_base.c: In function 'PKIEntityVerify':
+pki_entity_base.c:2074:24: error: 'retStatus' may be used
+	uninitialized in this function [-Werror=maybe-uninitialized]
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+---
+ source/util_api/asn.1/components/al_pki/pki_entity_base.c     | 4 ++--
+ .../asn.1/components/al_pki/smartcard_sample_entity.c         | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/source/util_api/asn.1/components/al_pki/pki_entity_base.c b/source/util_api/asn.1/components/al_pki/pki_entity_base.c
+index 02b280a..7419fa7 100644
+--- a/source/util_api/asn.1/components/al_pki/pki_entity_base.c
++++ b/source/util_api/asn.1/components/al_pki/pki_entity_base.c
+@@ -1878,7 +1878,7 @@ PKIEntitySignData
+     PKI_KEY_TYPE                    keyType;
+     int                             nHashMethod;
+     PANSC_CRYPTO_PUB_KEY_GEN_PARAMS pGenParams;
+-    ANSC_STATUS                     retStatus;
++    ANSC_STATUS                     retStatus   = ANSC_STATUS_FAILURE;
+ 
+     if( hThisObject == NULL || pDataWillBeSigned == NULL || pDataSigned == NULL || pLength == NULL)
+     {
+@@ -1990,7 +1990,7 @@ PKIEntityVerify
+     PANSC_CRYPTO_PUB_SSLEAY_OBJECT  pSSLCrypto   = NULL;
+     ANSC_CRYPTO_PUB_KEY_PARAMS      params;
+     PKI_KEY_TYPE                    keyType;
+-    ANSC_STATUS                     retStatus;
++    ANSC_STATUS                     retStatus   = ANSC_STATUS_FAILURE;
+     ANSC_CRYPTO_PUB_KEY_GEN_PARAMS  genParams;
+     UINT                            nHashMethod;
+ 
+diff --git a/source/util_api/asn.1/components/al_pki/smartcard_sample_entity.c b/source/util_api/asn.1/components/al_pki/smartcard_sample_entity.c
+index fb3a1cc..a3fdcab 100644
+--- a/source/util_api/asn.1/components/al_pki/smartcard_sample_entity.c
++++ b/source/util_api/asn.1/components/al_pki/smartcard_sample_entity.c
+@@ -140,7 +140,7 @@ SmartCardSignData
+     PKI_KEY_TYPE                    keyType;
+     int                             nHashMethod;
+     PANSC_CRYPTO_PUB_KEY_GEN_PARAMS pGenParams;
+-    ANSC_STATUS                     retStatus;
++    ANSC_STATUS                     retStatus = ANSC_STATUS_FAILURE;
+ 
+     pSSLCrypto = (PANSC_CRYPTO_PUB_SSLEAY_OBJECT)pThisObject->hCryptoSSL;
+ 

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0008-util_api-al_pkcs12-fix-uninitialized-variable-error.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0008-util_api-al_pkcs12-fix-uninitialized-variable-error.patch
@@ -1,0 +1,34 @@
+From 071dec24a498c36f3ff98a5a4c35dd45228486cd Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Wed, 22 Apr 2026 00:40:17 +0000
+Subject: [PATCH] util_api: al_pkcs12: fix uninitialized variable error
+
+When BitBake has debug build features enabled, the following error
+may appear:
+pkcs12_utility_api.c:708:29: error: 'n' may be used uninitialized
+in this function [-Werror=maybe-uninitialized]
+
+'n' is derived from the KeyId switch statement which lacks a
+default case, because the 'default' is constained above to n=1;
+
+However, the compiler cannot follow this.
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+---
+ .../util_api/asn.1/components/al_pkcs12/pkcs12_utility_api.c   | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/source/util_api/asn.1/components/al_pkcs12/pkcs12_utility_api.c b/source/util_api/asn.1/components/al_pkcs12/pkcs12_utility_api.c
+index bb5a6d6..43b1e59 100644
+--- a/source/util_api/asn.1/components/al_pkcs12/pkcs12_utility_api.c
++++ b/source/util_api/asn.1/components/al_pkcs12/pkcs12_utility_api.c
+@@ -660,7 +660,8 @@ PKCS12UtilityGetDerivedKey
+     PUCHAR                          pDiver      = NULL;
+     PUCHAR                          pBMPPassword= NULL; 
+     ULONG                           u;
+-    ULONG                           i, j, n, cycle;
++    ULONG                           i, j, cycle;
++    ULONG                           n           = 0;
+     ULONG                           passLength;
+     ULONG                           lenOfBMPPass;
+     ULONG                           lenOfPass;

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0009-cosa-assert-AnscCopyString-can-not-be-called-same.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library/0009-cosa-assert-AnscCopyString-can-not-be-called-same.patch
@@ -1,0 +1,27 @@
+From 58aa5f466030a34eb76bcb8bf9ef7a2c0477bb3b Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Wed, 22 Apr 2026 04:37:33 +0000
+Subject: [PATCH] cosa: assert AnscCopyString can not be called with same
+ source/destination
+
+This is to resolve a compile error found elsewhere in RDK-B
+when BitBake DEBUG_BUILD="1" is active.
+---
+ source/cosa/include/ansc_string.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/source/cosa/include/ansc_string.h b/source/cosa/include/ansc_string.h
+index 6048cab..2ffb320 100644
+--- a/source/cosa/include/ansc_string.h
++++ b/source/cosa/include/ansc_string.h
+@@ -86,6 +86,7 @@ static inline size_t AnscSizeOfString (const char *s)
+ 
+ static inline void AnscCopyString (char *d, const char *s)
+ {
++    assert(s != d);
+     if (!s)
+         *d = 0;
+     else
+-- 
+2.39.5
+

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-hotspot.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-hotspot.bbappend
@@ -1,1 +1,6 @@
 require ccsp_common_genericarm.inc
+
+# In function 'snoop_AddClientListEntry':
+# dhcpsnooper.c:864:57: error: 'pNewClient' may be used
+# uninitialized in this function [-Werror=maybe-uninitialized]
+CFLAGS:append = " -Wno-error=maybe-uninitialized"

--- a/meta-rdk-broadband/recipes-ccsp/hal/rdk-wifi-hal.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/hal/rdk-wifi-hal.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append = " \
 
 CFLAGS:append = " \
 	-fcommon \
+	-Wno-error=maybe-uninitialized \
 "
 
 # Use Raspberry Pi platform file as a base

--- a/meta-rdk-broadband/recipes-common/telemetry/telemetry_%.bbappend
+++ b/meta-rdk-broadband/recipes-common/telemetry/telemetry_%.bbappend
@@ -1,0 +1,3 @@
+# Workaround a compile issue when BUILD_DEBUG="1"
+
+CFLAGS:append = " -Wno-error=maybe-uninitialized"


### PR DESCRIPTION
When the BitBake environment is configured to build with [maximum debugging information](https://docs.yoctoproject.org/dev/dev-manual/debugging.html#debugging-with-the-gnu-project-debugger-gdb-on-the-target), there are a few compiler errors as a result of compiler flags being changed.

Most of these are cases where a variable is declared without an initial assignment (like `int err;`), and the compiler isn't sure that they are ever initialized.

```
commit 55c47c64fe5177113979199909b25b8901100138 (HEAD -> fix-debug-compile-issues)
Author: Mathew McBride <matt@traverse.com.au>
Date:   Wed Apr 22 14:46:11 2026 +1000

    ccsp-common-library: fix a compile issue when DEBUG_BUILD="1" active

    rdk-vlanmanager build fails with this error:

    vlan_dml.c: In function 'Vlan_Rollback':
    ansc_string.h:92:9: error: 'strcpy' source argument is the same as destination [-Werror=restrict]

    Looking at the source, the 'failure' path is not clear.
    Adding a forced check should get around the compiler error.

commit ac219bc58a6d6fcfb2fc2667663843f564b3d33c
Author: Mathew McBride <matt@traverse.com.au>
Date:   Wed Apr 22 14:10:14 2026 +1000

    ccsp-hotspot: work around compiler error when DEBUG_BUILD="1"

    dhcpsnooper.c:864:57: error: 'pNewClient' may be used
    uninitialized in this function [-Werror=maybe-uninitialized]

commit 143bb141fb24f1fbaf86b7e37f3dd80eca55f9ea
Author: Mathew McBride <matt@traverse.com.au>
Date:   Wed Apr 22 14:06:34 2026 +1000

    rdk-wifi-hal: workaround compile error when DEBUG_BUILD="1"

    wifi_hal_nl80211_utils.c: In function 'json_parse_interface_map':
    wifi_hal_nl80211_utils.c:5275:8: error: 'valid' may be used
    uninitialized in this function [-Werror=maybe-uninitialized]

     5275 |     if (!valid) {
commit 0246172ccaa26f8641f44abb5c3881ef0da75569
Author: Mathew McBride <matt@traverse.com.au>
Date:   Wed Apr 22 11:15:31 2026 +1000

    telemetry: workaround compile error with DEBUG_BUILD="1"

    xconfclient.c: In function 'getUpdatedConfigurationThread':
    xconfclient.c:911:16: error: 'urlFetchStatus' may be used
            uninitialized in this function [-Werror=maybe-uninitialized]

commit d3c942e82b879a91061b58d2d65842d21b49f89b
Author: Mathew McBride <matt@traverse.com.au>
Date:   Wed Apr 22 10:59:34 2026 +1000

    ccsp-common-library: resolve compile issues when DEBUG_BUILD="1"

    There are a few "'x' may be used uninitialized in this function"
    issues in ccsp-common-library's util_api.
```
