### PR TITLE
Fix compile error in start-parodus

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/start-parodus.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/start-parodus.bbappend
@@ -1,0 +1,7 @@
+require ccsp_common_genericarm.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " file://0001-start_parodus-align-generic-ARM-platform-with-other-.patch"
+
+CFLAGS:remove = "-DPLATFORM_RASPBERRYPI"

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/start-parodus/0001-start_parodus-align-generic-ARM-platform-with-other-.patch
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/start-parodus/0001-start_parodus-align-generic-ARM-platform-with-other-.patch
@@ -1,0 +1,41 @@
+From 65a7bf6b6ea750bef495dfba46799550ce55f881 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Wed, 13 May 2026 01:08:02 +0000
+Subject: [PATCH] start_parodus: align generic ARM platform with other RDK
+ reference platforms
+
+---
+ source/parodusStart/start_parodus.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/source/parodusStart/start_parodus.c b/source/parodusStart/start_parodus.c
+index c7b3221..2bc1769 100644
+--- a/source/parodusStart/start_parodus.c
++++ b/source/parodusStart/start_parodus.c
+@@ -46,7 +46,7 @@
+ #include "cJSON.h"
+ #include "safec_lib_common.h"
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_) || defined(_PLATFORM_BANANAPI_R4_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_GENERICARM_) || defined(_PLATFORM_BANANAPI_R4_)
+ #include "ccsp_vendor.h"
+ #endif
+ 
+@@ -242,7 +242,7 @@ int main(int argc, char *argv[])
+ 	char manufacturer[64]={'\0'};
+ #if defined(_COSA_BCM_MIPS_)
+ 	dpoe_mac_address_t tDpoe_Mac;
+-#elif !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
++#elif !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
+ 	CMMGMT_CM_DHCP_INFO dhcpinfo;
+ #endif
+ 	char parodus_url[MAX_SERVER_URL_SIZE] = {'\0'};
+@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
+                   backoffRetryTime = (int)pow(2, c) - 1;
+               }
+ 
+-	      #if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_)
++	      #if !defined(_PLATFORM_RASPBERRYPI_) && !defined(_PLATFORM_BANANAPI_R4_) && !defined(_PLATFORM_GENERICARM_)
+               if (cm_hal_GetDHCPInfo(&dhcpinfo) == 0)
+ 	      {
+ 		  LogInfo("MACAddress = %s\n", dhcpinfo.MACAddress);


### PR DESCRIPTION
While evaluating the WebPA changes (#86), I encountered this error: 

```
from parodusStart/start_parodus.c:47:
parodusStart/start_parodus.c: In function 'main':
parodusStart/start_parodus.c:328:59: error:
'CONFIG_VENDOR_NAME' undeclared (first use in this function)
  328 |         rc = strcpy_s(manufacturer, sizeof(manufacturer), CONFIG_VENDOR_NAME);
      |                                                           ^~~~~~~~~~~~~~~~~~
````

The issue is caused by ccsp_vendor.h not being imported on our platform. Add a bbappend to put this into effect

