### PR TITLE
ucresolv: workaround compile error in debug build

### DIFF
--- a/meta-rdk-ext/recipes-support/ucresolv/ucresolv_%.bbappend
+++ b/meta-rdk-ext/recipes-support/ucresolv/ucresolv_%.bbappend
@@ -1,0 +1,1 @@
+CFLAGS:append = " -Wno-error=maybe-uninitialized"


### PR DESCRIPTION
When Yocto/Bitbake's DEBUG_BUILD flag is enabled, the following compile error occurs

```
res_send.c:1037:21: error: 'slen' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1037 |                 if (connect(EXT(statp).nssocks[ns], nsap, slen) < 0) {

cc1: all warnings being treated as errors
```

