### PR TITLE
incus-init: automatically install Incus agent on Incus VM host

### DIFF
--- a/meta-rdk-broadband/recipes-rdkb/sysint-broadband/files/btrfs-subvolume.service
+++ b/meta-rdk-broadband/recipes-rdkb/sysint-broadband/files/btrfs-subvolume.service
@@ -2,9 +2,9 @@
 Description=btrfs subvolume management
 
 [Service]
-Type=oneshot
+Type=notify
 ExecStart=/bin/sh /lib/rdk/btrfs/nvram-subvol-init.sh
 SyslogIdentifier=btrfs-subvolume
 
 [Install]
-WantedBy=local-fs.target
+RequiredBy=local-fs.target

--- a/meta-rdk-broadband/recipes-rdkb/sysint-broadband/files/nvram-subvol-init.sh
+++ b/meta-rdk-broadband/recipes-rdkb/sysint-broadband/files/nvram-subvol-init.sh
@@ -45,3 +45,4 @@ if (grep -q -E " / btrfs" /proc/mounts) && ! (grep -q -E "/nvram btrfs" /proc/mo
 	fi
 	mkdir -p "/rdklogs/logs2"
 fi
+systemd-notify --ready

--- a/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -37,6 +37,8 @@ IMAGE_INSTALL:append = "${@bb.utils.contains('DISTRO_FEATURES', 'with_alsap',' i
 # Webpa
 IMAGE_INSTALL:append = " parodus parodus2ccsp"
 
+IMAGE_INSTALL:append = " incus-agent"
+
 require image-exclude-files.inc
 
 remove_unused_file() {
@@ -48,6 +50,8 @@ ROOTFS_POSTPROCESS_COMMAND:append = "remove_unused_file; "
 
 ROOTFS_POSTPROCESS_COMMAND:append = "add_busybox_fixes; "
 
+ROOTFS_POSTPROCESS_COMMAND:append = "add_root_symlink; "
+
 add_busybox_fixes() {
                 if [  -d ${IMAGE_ROOTFS}/bin ]; then
 			cd  ${IMAGE_ROOTFS}/bin
@@ -58,4 +62,10 @@ add_busybox_fixes() {
                 fi
 }
 
+# The Incus agent expects to have a /root
+# folder when executing commands via
+# `incus exec`
+add_root_symlink() {
+		ln -sfr ${IMAGE_ROOTFS}/home/root ${IMAGE_ROOTFS}/root
+}
 # ----------------------------------------------------------------------------

--- a/recipes-virtualization/incus-agent/files/install-incus-agent.service
+++ b/recipes-virtualization/incus-agent/files/install-incus-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Incus agent auto installation
+ConditionVirtualization=kvm
+ConditionPathExists=!/lib/systemd/incus-agent-setup
+Requires=btrfs-subvolume.service
+After=btrfs-subvolume.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/install-incus-agent.sh
+SyslogIdentifier=install-incus-agent
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-virtualization/incus-agent/files/install-incus-agent.sh
+++ b/recipes-virtualization/incus-agent/files/install-incus-agent.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+###############################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+#  Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+if [ -f "/lib/systemd/incus-agent-setup" ]; then
+	exit 0
+fi
+
+DMI_BOARD_NAME=$(cat /sys/class/dmi/id/board_name)
+if [ "${DMI_BOARD_NAME}" = "Incus" ] ; then
+	echo "We are running on Incus, installing agent"
+	mount -t 9p config /mnt
+	cd /mnt
+	./install.sh 1>/rdklogs/incus-agent-install.log 2>&1
+	cd /
+	umount /mnt
+	sleep 1
+	systemctl start incus-agent 1>/rdklogs/incus-agent-start.log 2>&1
+	systemctl status incus-agent >>/rdklogs/incus-agent-start.log
+fi
+
+exit 0

--- a/recipes-virtualization/incus-agent/incus-agent.bb
+++ b/recipes-virtualization/incus-agent/incus-agent.bb
@@ -1,0 +1,26 @@
+inherit systemd
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+
+DESCRIPTION = "Hook to automatically install Incus agent"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/install-incus-agent.sh;beginline=2;endline=19;md5=9ccd86322e8b3587f7d5f8eb82a2e0a2"
+
+SRC_URI = "\
+    file://install-incus-agent.service \
+    file://install-incus-agent.sh \
+"
+
+do_install() {
+    install -d ${D}${systemd_unitdir}/system
+    install -m 644 ${WORKDIR}/install-incus-agent.service ${D}${systemd_unitdir}/system
+    install -d ${D}${sbindir}
+    install -m 755 ${WORKDIR}/install-incus-agent.sh ${D}${sbindir}
+}
+
+SYSTEMD_SERVICE:${PN} = "install-incus-agent.service"
+
+FILES:${PN} = " \
+	${systemd_unitdir}/system/install-incus-agent.service \
+	${sbindir}/install-incus-agent.sh \
+"


### PR DESCRIPTION
The incus agent is used to enable Host-to-VM communication on the Incus virtual machine manager. It provides functions like providing shell access to the VM from host and showing the VM's current IP addresses.

When running under Incus we can mount a shared folder with 9p that contains the install script for the agent. We do not need to ship the agent ourselves.

See the wiki page for more information: https://github.com/rdkcentral/meta-rdk-bsp-arm/wiki/Incus  