### PR TITLE
ISSUE-108, RDKBACCL-1766: Webconfig Support on ARM system Ready

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -156,6 +156,7 @@ fi' ${D}/usr/ccsp/ccspPAMCPCheck.sh
     if ${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', 'true', 'false', d)}; then
         install -D -m 0644 ${S}/systemd_units/webconfig.service ${D}${systemd_unitdir}/system/webconfig.service
     fi
+    sed -i "s/wan-initialized.target/multi-user.target/g" ${D}${systemd_unitdir}/system/webconfig.service
     install -D -m 0644 ${S}/systemd_units/wan-initialized.target ${D}${systemd_unitdir}/system/wan-initialized.target
     install -D -m 0644 ${S}/systemd_units/wan-initialized.path ${D}${systemd_unitdir}/system/wan-initialized.path
 

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/cpeabs_1.0.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/cpeabs_1.0.bbappend
@@ -1,1 +1,1 @@
-CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', '-DPLATFORM_RASPBERRYPI', '', d)}"
+CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', '-D_PLATFORM_GENERICARM_', '', d)}"

--- a/recipes-support/webcfg/webcfg/webconfig_metadata.json
+++ b/recipes-support/webcfg/webcfg/webconfig_metadata.json
@@ -20,24 +20,6 @@
                                   "bitposition": 3,
                                   "support": true,
                                   "version": "1.0"
-                               },
-                               {
-                                  "name": "macbinding",
-                                  "bitposition": 4,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "hotspot",
-                                  "bitposition": 5,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "bridge",
-                                  "bitposition": 6,
-                                  "support": false,
-                                  "version": "1.0"
                                }
                             ]
                },
@@ -51,14 +33,8 @@
                                   "version": "1.0"
                                },
                                {
-                                  "name": "homessid",
-                                  "bitposition": 2,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
                                   "name": "radio",
-                                  "bitposition": 3,
+                                  "bitposition": 2,
                                   "support": false,
                                   "version": "1.0"
                                }
@@ -68,167 +44,11 @@
                  "group_id": 3,
 	             "subdocs": [
                                {
-                                  "name": "moca",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 4,
-	             "subdocs": [
-                               {
-                                  "name": "xdns",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 5,
-	             "subdocs": [
-                               {
-                                  "name": "advsecurity",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 6,
-	             "subdocs": [
-                               {
-                                  "name": "mesh",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 7,
-	             "subdocs": [
-                               {
-                                  "name": "aker",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 8,
-	             "subdocs": [
-                               {
                                   "name": "telemetry",
                                   "bitposition": 1,
                                   "support": true,
                                   "version": "1.0",
                                   "secondary_doc": true
-                               }
-                            ]
-               },
-               {
-                 "group_id": 9,
-	             "subdocs": [
-                               {
-                                  "name": "trafficreport",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "statusreport",
-                                  "bitposition": 2,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 10,
-	             "subdocs": [
-                               {
-                                  "name": "radioreport",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "interfacereport",
-                                  "bitposition": 2,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 11,
-                 "subdocs": [
-                   {
-                     "name": "telcovoip",
-                     "bitposition": 1,
-                     "support": false,
-                     "version": "1.0"
-                   },
-                   {
-                     "name": "telcovoice",
-                     "bitposition": 2,
-                     "support": false,
-                     "version": "1.0"
-                   }
-                 ]
-               },
-               {
-                 "group_id": 12,
-                 "subdocs": [
-                   {
-                     "name": "wanmanager",
-                     "bitposition": 1,
-                     "support": false,
-                     "version": "1.0"
-                   },
-                   {
-                       "name": "wanfailover",
-                       "bitposition": 2,
-                       "support": true,
-                       "version": "1.0"
-                   }
-                 ]
-               },
-	       {
-                 "group_id": 13,
-	             "subdocs": [
-                               {
-                                  "name": "voiceservice",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-			   {
-                 "group_id": 14,
-	             "subdocs": [
-                               {
-                                  "name": "cellularconfig",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-			   {
-                 "group_id": 15,
-                     "subdocs": [
-                   	       {
-                     		  "name": "gwfailover",
-                     		  "bitposition": 1,
-                     		  "support": true,
-                     		  "version": "1.0"
                                }
                             ]
                }
@@ -254,24 +74,6 @@
                                   "bitposition": 3,
                                   "support": true,
                                   "version": "1.0"
-                               },
-                               {
-                                  "name": "macbinding",
-                                  "bitposition": 4,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "hotspot",
-                                  "bitposition": 5,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "bridge",
-                                  "bitposition": 6,
-                                  "support": false,
-                                  "version": "1.0"
                                }
                             ]
                },
@@ -285,14 +87,8 @@
                                   "version": "1.0"
                                },
                                {
-                                  "name": "homessid",
-                                  "bitposition": 2,
-                                  "support": true,
-                                  "version": "1.0"
-                               },
-                               {
                                   "name": "radio",
-                                  "bitposition": 3,
+                                  "bitposition": 2,
                                   "support": false,
                                   "version": "1.0"
                                }
@@ -302,167 +98,11 @@
                  "group_id": 3,
 	             "subdocs": [
                                {
-                                  "name": "moca",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 4,
-	             "subdocs": [
-                               {
-                                  "name": "xdns",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 5,
-	             "subdocs": [
-                               {
-                                  "name": "advsecurity",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 6,
-	             "subdocs": [
-                               {
-                                  "name": "mesh",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 7,
-	             "subdocs": [
-                               {
-                                  "name": "aker",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 8,
-	             "subdocs": [
-                               {
                                   "name": "telemetry",
                                   "bitposition": 1,
                                   "support": true,
                                   "version": "1.0",
                                   "secondary_doc": true
-                               }
-                            ]
-               },
-               {
-                 "group_id": 9,
-	             "subdocs": [
-                               {
-                                  "name": "trafficreport",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "statusreport",
-                                  "bitposition": 2,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 10,
-	             "subdocs": [
-                               {
-                                  "name": "radioreport",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               },
-                               {
-                                  "name": "interfacereport",
-                                  "bitposition": 2,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-               {
-                 "group_id": 11,
-                 "subdocs": [
-                   {
-                     "name": "telcovoip",
-                     "bitposition": 1,
-                     "support": false,
-                     "version": "1.0"
-                   },
-                   {
-                     "name": "telcovoice",
-                     "bitposition": 2,
-                     "support": false,
-                     "version": "1.0"
-                   }
-                 ]
-               },
-               {
-                 "group_id": 12,
-                 "subdocs": [
-                   {
-                     "name": "wanmanager",
-                     "bitposition": 1,
-                     "support": false,
-                     "version": "1.0"
-                   },
-                   {
-                       "name": "wanfailover",
-                       "bitposition": 2,
-                       "support": true,
-                       "version": "1.0"
-                   }
-                 ]
-               },
-	       {
-                 "group_id": 13,
-	             "subdocs": [
-                               {
-                                  "name": "voiceservice",
-                                  "bitposition": 1,
-                                  "support": true,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-			   {
-                 "group_id": 14,
-	             "subdocs": [
-                               {
-                                  "name": "cellularconfig",
-                                  "bitposition": 1,
-                                  "support": false,
-                                  "version": "1.0"
-                               }
-                            ]
-               },
-			   {
-                 "group_id": 15,
-                     "subdocs": [
-                   	       {
-                     		  "name": "gwfailover",
-                     		  "bitposition": 1,
-                     		  "support": true,
-                     		  "version": "1.0"
                                }
                             ]
                }

--- a/recipes-support/webcfg/webcfg/webconfig_metadata.json
+++ b/recipes-support/webcfg/webcfg/webconfig_metadata.json
@@ -1,0 +1,470 @@
+{
+    "armefi64-rdk-broadband" : [
+              {
+                 "group_id": 1,
+	             "subdocs": [
+                               {
+                                  "name": "portforwarding",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "wan",
+                                  "bitposition": 2,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "lan",
+                                  "bitposition": 3,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "macbinding",
+                                  "bitposition": 4,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "hotspot",
+                                  "bitposition": 5,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "bridge",
+                                  "bitposition": 6,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 2,
+	             "subdocs": [
+                               {
+                                  "name": "privatessid",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "homessid",
+                                  "bitposition": 2,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "radio",
+                                  "bitposition": 3,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 3,
+	             "subdocs": [
+                               {
+                                  "name": "moca",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 4,
+	             "subdocs": [
+                               {
+                                  "name": "xdns",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 5,
+	             "subdocs": [
+                               {
+                                  "name": "advsecurity",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 6,
+	             "subdocs": [
+                               {
+                                  "name": "mesh",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 7,
+	             "subdocs": [
+                               {
+                                  "name": "aker",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 8,
+	             "subdocs": [
+                               {
+                                  "name": "telemetry",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0",
+                                  "secondary_doc": true
+                               }
+                            ]
+               },
+               {
+                 "group_id": 9,
+	             "subdocs": [
+                               {
+                                  "name": "trafficreport",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "statusreport",
+                                  "bitposition": 2,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 10,
+	             "subdocs": [
+                               {
+                                  "name": "radioreport",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "interfacereport",
+                                  "bitposition": 2,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 11,
+                 "subdocs": [
+                   {
+                     "name": "telcovoip",
+                     "bitposition": 1,
+                     "support": false,
+                     "version": "1.0"
+                   },
+                   {
+                     "name": "telcovoice",
+                     "bitposition": 2,
+                     "support": false,
+                     "version": "1.0"
+                   }
+                 ]
+               },
+               {
+                 "group_id": 12,
+                 "subdocs": [
+                   {
+                     "name": "wanmanager",
+                     "bitposition": 1,
+                     "support": false,
+                     "version": "1.0"
+                   },
+                   {
+                       "name": "wanfailover",
+                       "bitposition": 2,
+                       "support": true,
+                       "version": "1.0"
+                   }
+                 ]
+               },
+	       {
+                 "group_id": 13,
+	             "subdocs": [
+                               {
+                                  "name": "voiceservice",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+			   {
+                 "group_id": 14,
+	             "subdocs": [
+                               {
+                                  "name": "cellularconfig",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+			   {
+                 "group_id": 15,
+                     "subdocs": [
+                   	       {
+                     		  "name": "gwfailover",
+                     		  "bitposition": 1,
+                     		  "support": true,
+                     		  "version": "1.0"
+                               }
+                            ]
+               }
+             ],
+    "raspberrypi64-rdk-broadband" : [
+              {
+                 "group_id": 1,
+	             "subdocs": [
+                               {
+                                  "name": "portforwarding",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "wan",
+                                  "bitposition": 2,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "lan",
+                                  "bitposition": 3,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "macbinding",
+                                  "bitposition": 4,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "hotspot",
+                                  "bitposition": 5,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "bridge",
+                                  "bitposition": 6,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 2,
+	             "subdocs": [
+                               {
+                                  "name": "privatessid",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "homessid",
+                                  "bitposition": 2,
+                                  "support": true,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "radio",
+                                  "bitposition": 3,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 3,
+	             "subdocs": [
+                               {
+                                  "name": "moca",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 4,
+	             "subdocs": [
+                               {
+                                  "name": "xdns",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 5,
+	             "subdocs": [
+                               {
+                                  "name": "advsecurity",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 6,
+	             "subdocs": [
+                               {
+                                  "name": "mesh",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 7,
+	             "subdocs": [
+                               {
+                                  "name": "aker",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 8,
+	             "subdocs": [
+                               {
+                                  "name": "telemetry",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0",
+                                  "secondary_doc": true
+                               }
+                            ]
+               },
+               {
+                 "group_id": 9,
+	             "subdocs": [
+                               {
+                                  "name": "trafficreport",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "statusreport",
+                                  "bitposition": 2,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 10,
+	             "subdocs": [
+                               {
+                                  "name": "radioreport",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               },
+                               {
+                                  "name": "interfacereport",
+                                  "bitposition": 2,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+               {
+                 "group_id": 11,
+                 "subdocs": [
+                   {
+                     "name": "telcovoip",
+                     "bitposition": 1,
+                     "support": false,
+                     "version": "1.0"
+                   },
+                   {
+                     "name": "telcovoice",
+                     "bitposition": 2,
+                     "support": false,
+                     "version": "1.0"
+                   }
+                 ]
+               },
+               {
+                 "group_id": 12,
+                 "subdocs": [
+                   {
+                     "name": "wanmanager",
+                     "bitposition": 1,
+                     "support": false,
+                     "version": "1.0"
+                   },
+                   {
+                       "name": "wanfailover",
+                       "bitposition": 2,
+                       "support": true,
+                       "version": "1.0"
+                   }
+                 ]
+               },
+	       {
+                 "group_id": 13,
+	             "subdocs": [
+                               {
+                                  "name": "voiceservice",
+                                  "bitposition": 1,
+                                  "support": true,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+			   {
+                 "group_id": 14,
+	             "subdocs": [
+                               {
+                                  "name": "cellularconfig",
+                                  "bitposition": 1,
+                                  "support": false,
+                                  "version": "1.0"
+                               }
+                            ]
+               },
+			   {
+                 "group_id": 15,
+                     "subdocs": [
+                   	       {
+                     		  "name": "gwfailover",
+                     		  "bitposition": 1,
+                     		  "support": true,
+                     		  "version": "1.0"
+                               }
+                            ]
+               }
+             ]
+}

--- a/recipes-support/webcfg/webcfg_1.0.bbappend
+++ b/recipes-support/webcfg/webcfg_1.0.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'webconfig_bin', 'file://webconfig_metadata.json', '', d)}"
+
+inherit breakpad-wrapper
+DEPENDS += "breakpad breakpad-wrapper"
+BREAKPAD_BIN_append = " webconfig"
+
+LDFLAGS += "-lbreakpadwrapper -lpthread -lstdc++"
+CFLAGS += "-DINCLUDE_BREAKPAD"
+
+# generating minidumps
+PACKAGECONFIG_append = "breakpad"


### PR DESCRIPTION
Reason for change: Bringing webconfig support in ARM system ready Test procedure: By default X_RDK_WebConfig.RfcEnable will be enabled state, once device boots up supportedocs will be updated. Update the set chnages from webconfig server.

Depended PR : https://github.com/xmidt-org/cpeabs/pull/54

Complete steps to test webconfig is captured in wiki https://wiki.rdkcentral.com/spaces/RDK/pages/355763791/WebConfig+Feature+Support+in+RDKB+BPI+-+User+Manual

```
root@rdkb-arm:~# dmcli eRT getv Device.X_RDK_WebConfig.
CR component name is: eRT.com.cisco.spvtg.ccsp.CR
subsystem_prefix eRT.
Execution succeed.
Parameter    1 name: Device.X_RDK_WebConfig.RfcEnable
               type:       bool,    value: true 
Parameter    2 name: Device.X_RDK_WebConfig.Data
               type:     string,    value: gap3ZWJjZmdibG9ikYakbmFtZaRyb290p3ZlcnNpb24ApnN0YXR1c6dzdWNjZXNzrWVycm9yX2RldGFpbHOkbm9uZaplcnJvcl9jb2RlAKtyb290X3N0cmluZ6tOT05FLVJFQk9PVA== 
Parameter    3 name: Device.X_RDK_WebConfig.SupportedDocs
               type:     string,    value: 16777247,33554435,50331649,67108865,83886081,100663297,117440513,134217729,201326594,218103809 
Parameter    4 name: Device.X_RDK_WebConfig.SupportedSchemaVersion
               type:     string,    value:  
Parameter    5 name: Device.X_RDK_WebConfig.webcfgSubdocForceReset
               type:     string,    value:  
Parameter    6 name: Device.X_RDK_WebConfig.URL
               type:     string,    value: https://webconfig.rdkcentral.com/api/v1/device/000afa2435a6/config 
Parameter    7 name: Device.X_RDK_WebConfig.ForceSync
               type:     string,    value:  
Parameter    8 name: Device.X_RDK_WebConfig.SupplementaryServiceUrls.Telemetry
               type:     string,    value: https://webconfig.rdkcentral.com/api/v1/device/000afa2435a6/config 

```