### PR TITLE
Update ModemManager

### DIFF
--- a/conf/distro/include/rdk-genericarm.inc
+++ b/conf/distro/include/rdk-genericarm.inc
@@ -91,7 +91,7 @@ DISTRO_FEATURES:append:broadband = " cellular_mgr_lite"
 DISTRO_FEATURES:append:broadband = " cellular_libqmi_support"
 
 #RNDIS Feature
-DISTRO_FEATURES_append_broadband = " cellular_hybrid_support"
+#DISTRO_FEATURES_append_broadband = " cellular_hybrid_support"
 DISTRO_FEATURES:append:broadband = " rdkb_power_manager"
 #DISTRO_FEATURES:append:broadband = " rdkb_gpon_manager"
 DISTRO_FEATURES:append:broadband = " rdkb_wan_manager"

--- a/recipes-connectivity/libmbim/libmbim_1.30.0.bb
+++ b/recipes-connectivity/libmbim/libmbim_1.30.0.bb
@@ -1,0 +1,26 @@
+# This bitbake recipe is sourced from Yocto release 4.3 (nanbield)
+# https://layers.openembedded.org/layerindex/recipe/350778/
+# Reason: newer version required to support hardware and network
+
+SUMMARY = "libmbim is library for talking to WWAN devices by MBIM protocol"
+DESCRIPTION = "libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libmbim/"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = " \
+    file://LICENSES/GPL-2.0-or-later.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://LICENSES/LGPL-2.1-or-later.txt;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libgudev"
+
+inherit meson pkgconfig bash-completion gobject-introspection
+
+SRCREV = "8415687e4f30ae5e36f407f179c8147f1529725c"
+SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libmbim.git;protocol=https;branch=mbim-1-30"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMESON = " \
+    -Dgtk_doc=false \
+    -Dman=false \
+"

--- a/recipes-connectivity/libqmi/libqmi_1.34.0.bb
+++ b/recipes-connectivity/libqmi/libqmi_1.34.0.bb
@@ -1,0 +1,32 @@
+# This bitbake recipe is sourced from Yocto release 4.3 (nanbield)
+# https://layers.openembedded.org/layerindex/recipe/350776/
+# Reason: newer version required to support hardware and network
+
+SUMMARY = "libqmi is a library for talking to WWAN devices by QMI protocol"
+DESCRIPTION = "libqmi is a glib-based library for talking to WWAN modems and \
+               devices which speak the Qualcomm MSM Interface (QMI) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libqmi"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native"
+
+inherit meson pkgconfig bash-completion gobject-introspection
+
+SRCREV = "3f07d6e5b4677558543b3b4484ea88ad92257e92"
+SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/libqmi.git;protocol=https;branch=qmi-1-34"
+
+S = "${WORKDIR}/git"
+
+PACKAGECONFIG ??= "udev mbim"
+PACKAGECONFIG[udev] = "-Dudev=true,-Dudev=false,libgudev"
+PACKAGECONFIG[mbim] = "-Dmbim_qmux=true,-Dmbim_qmux=false,libmbim"
+PACKAGECONFIG[qrtr] = "-Dqrtr=true,-Dqrtr=false,libqrtr-glib"
+
+EXTRA_OEMESON = " \
+    -Dgtk_doc=false \
+    -Dman=false \
+"

--- a/recipes-connectivity/modemmanager/modemmanager_1.22.0.bb
+++ b/recipes-connectivity/modemmanager/modemmanager_1.22.0.bb
@@ -1,0 +1,60 @@
+# This bitbake recipe is sourced from Yocto release 4.3 (nanbield)
+# https://layers.openembedded.org/layerindex/recipe/350778/
+# Reason: newer version required to support hardware and network
+
+SUMMARY = "ModemManager is a daemon controlling broadband devices/connections"
+DESCRIPTION = "ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/ModemManager/"
+LICENSE = "GPL-2.0-or-later & LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+GNOMEBASEBUILDCLASS = "meson"
+inherit gnomebase gettext systemd gobject-introspection bash-completion
+
+DEPENDS = "glib-2.0 libgudev libxslt-native dbus"
+
+SRCREV = "03f786ce66360d67c669f4f122f8aa458e6f01ea"
+SRC_URI = "git://gitlab.freedesktop.org/mobile-broadband/ModemManager.git;protocol=https;branch=mm-1-22"
+
+S = "${WORKDIR}/git"
+
+# strict, permissive
+MODEMMANAGER_POLKIT_TYPE ??= "permissive"
+
+PACKAGECONFIG ??= "vala mbim qmi \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd polkit', d)} \
+"
+
+PACKAGECONFIG[at] = "-Dat_command_via_dbus=true"
+PACKAGECONFIG[systemd] = " \
+    -Dsystemdsystemunitdir=${systemd_unitdir}/system/, \
+    -Dsystemdsystemunitdir=no -Dsystemd_journal=false -Dsystemd_suspend_resume=false \
+"
+PACKAGECONFIG[polkit] = "-Dpolkit=${MODEMMANAGER_POLKIT_TYPE},-Dpolkit=no,polkit"
+# Support WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.
+PACKAGECONFIG[mbim] = "-Dmbim=true,-Dmbim=false -Dplugin_dell=disabled -Dplugin_foxconn=disabled,libmbim"
+# Support WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.
+PACKAGECONFIG[qmi] = "-Dqmi=true,-Dqmi=false,libqmi"
+PACKAGECONFIG[qrtr] = "-Dqrtr=true,-Dqrtr=false,libqrtr-glib"
+PACKAGECONFIG[vala] = "-Dvapi=true,-Dvapi=false"
+
+inherit ${@bb.utils.contains('PACKAGECONFIG', 'vala', 'vala', '', d)}
+
+EXTRA_OEMESON = " \
+    -Dudevdir=${nonarch_base_libdir}/udev \
+    -Dqrtr=false \
+"
+
+FILES:${PN} += " \
+    ${datadir}/icons \
+    ${datadir}/polkit-1 \
+    ${datadir}/dbus-1 \
+    ${datadir}/ModemManager \
+    ${libdir}/ModemManager \
+    ${systemd_unitdir}/system \
+"
+
+SYSTEMD_SERVICE:${PN} = "ModemManager.service"


### PR DESCRIPTION
As mentioned in https://github.com/rdkcentral/meta-rdk-bsp-arm/issues/81#issuecomment-4589772497 , a newer version of ModemManager and related components is required for SDX75 based modems such as Quectel RM520N. We also need to support 5G-SA networks which the existing version (1.18) might be too old to do.

ModemManager is now at 1.22, libmbim 1.30 and libqmi at 1.34.
The recipes were taken from Yocto 4.3.

Unfortunately I had to disable cellular hybrid (RNDIS) support to get the Quectel RM520N working.
Enabling RNDIS makes RdkCellularManager-MM use the QMI or MBIM path directly (see https://github.com/Ashrafbhanu-k/cellular-modem-manager/blob/509474fb5a37fdfc90bab1270ad563098b885b2e/README.md#mm_support-default )
Maybe we can find a solution to this?

I created a page in this repository wiki on how to enable the cellular modem:
https://github.com/rdkcentral/meta-rdk-bsp-arm/wiki/Cellular-Modem-user-guide
