### PR TITLE
Issue-105: Remove erouter0 dependency from usp-pa

### DIFF
--- a/meta-rdk-broadband/recipes-rdkb/usp-pa/usp-pa.bbappend
+++ b/meta-rdk-broadband/recipes-rdkb/usp-pa/usp-pa.bbappend
@@ -1,1 +1,7 @@
 EXTRA_OECONF:remove:kirkstone  = " --with-ccsp-platform=bcm --with-ccsp-arch=arm "
+
+do_install:append:class-target () {
+
+sed -i "/^ExecStart=/c\\ExecStart=/bin/sh -c '/usr/bin/obuspa --plugin /usr/libexec/usp-pa-vendor-rdk.so -v1 --resetfile /etc/usp-pa/usp_factory_reset.conf --truststore /etc/usp-pa/usp_truststore.pem --interface \"\$(sysevent get current_wan_ifname)\" --log syslog --dbfile /nvram/usp-pa.db'" ${D}${systemd_unitdir}/system/usp-pa.service
+
+}


### PR DESCRIPTION
currently usp-ps has dependency on erouter0 interface, since erouter0 was hardcoded.

with this approach, removed the dependency by fecthing wan interface name using sysevent.