### PR TITLE
Enable cellular interface for selection

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
@@ -1254,7 +1254,7 @@
 
   <Record name="dmsb.wanmanager.if.2.BaseInterface" type="astr">Device.Cellular.Interface.1</Record>
 
-  <Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">FALSE</Record>
+  <Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">TRUE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.ActiveLink" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.RequiresReboot" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.Group" type="astr">1</Record>


### PR DESCRIPTION
Currently cellular interface selection is set to false  in ARM due to this feature is working as expected(dmsb.wanmanager.if.2.Selection.Enable).

Before change:
Cellular interface selection enable set to FALSE
``` 
<Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">FALSE</Record>
```
After Change:
Cellualr Interface selection enable set to TRUE
```
<Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">TRUE</Record>
```