### PR TITLE
Remove utopia service depedency from parodus

### DIFF
--- a/meta-rdk-ext/recipes-support/parodus/parodus_1.0.bbappend
+++ b/meta-rdk-ext/recipes-support/parodus/parodus_1.0.bbappend
@@ -32,6 +32,8 @@ do_install:append:broadband () {
     install -m 0755 ${S}/devices/broadband/parodus/scripts/parodus_start.sh ${D}${base_libdir_native}/rdk
     sed -i 's/parodusCmd.cmd &/parodusCmd.cmd/' ${D}${systemd_unitdir}/system/parodus.service
     sed -i '/ExecStart=/a ExecStartPost\=\sysevent set webserver started'  ${D}${systemd_unitdir}/system/parodus.service
+    sed -i "s/After=utopia.service RdkWanManager.service PsmSsp.service CcspPandMSsp.service CcspLMLite.service/After=RdkWanManager.service PsmSsp.service CcspPandMSsp.service CcspLMLite.service/g" ${D}${systemd_unitdir}/system/parodus.service
+    sed -i "s/Requires=utopia.service RdkWanManager.service/Requires=RdkWanManager.service/g" ${D}${systemd_unitdir}/system/parodus.service
 }
 
 SYSTEMD_SERVICE:${PN}:append:broadband = " parodus.service"


### PR DESCRIPTION
Currently parodus service having the dependency on the utopia service since utopai sevice itsellf not available. so with this we are not able to restart the parodus servie.
```
root@rdkb-arm:/lib/systemd/system# systemctl restart parodus.service
Failed to restart RdkWanManager.service: Unit utopia.service not found.
root@rdkb-arm:
```
Before change:
```
Description=Parodus
After=utopia.service RdkWanManager.service PsmSsp.service CcspPandMSsp.service CcspLMLite.service
Requires=utopia.service RdkWanManager.service
```
After change:
```
Description=Parodus
After=RdkWanManager.service PsmSsp.service CcspPandMSsp.service CcspLMLite.service
Requires=RdkWanManager.service
```
