### PR TITLE
Move cellular interface into WAN Manager group 2, SFP into group 1

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
@@ -1254,7 +1254,7 @@
 
   <Record name="dmsb.wanmanager.if.2.BaseInterface" type="astr">Device.Cellular.Interface.1</Record>
 
-  <Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">FALSE</Record>
+  <Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">TRUE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.ActiveLink" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.RequiresReboot" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.Group" type="astr">1</Record>

--- a/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-psm/bbhm_def_cfg_ten64.xml
@@ -1257,7 +1257,7 @@
   <Record name="dmsb.wanmanager.if.2.Selection.Enable" type="astr">TRUE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.ActiveLink" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.RequiresReboot" type="astr">FALSE</Record>
-  <Record name="dmsb.wanmanager.if.2.Selection.Group" type="astr">1</Record>
+  <Record name="dmsb.wanmanager.if.2.Selection.Group" type="astr">2</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.Priority" type="astr">1</Record>
   <Record name="dmsb.wanmanager.if.2.Selection.Timeout" type="astr">20</Record>
 
@@ -1286,6 +1286,7 @@
   <Record name="dmsb.wanmanager.if.3.VirtualInterface.1.Alias" type="astr">SFPOE</Record>
   <Record name="dmsb.wanmanager.if.3.VirtualInterface.1.Name" type="astr">eth8</Record>
   <Record name="dmsb.wanmanager.if.3.Selection.Enable" type="astr">TRUE</Record>
+  <Record name="dmsb.wanmanager.if.3.Selection.Group" type="astr">1</Record>
   <Record name="dmsb.wanmanager.if.3.Selection.Priority" type="astr">2</Record>
   <Record name="dmsb.wanmanager.if.3.VirtualInterface.1.EnableMAPT" type="astr">FALSE</Record>
   <Record name="dmsb.wanmanager.if.3.VirtualInterface.1.EnableDSLite" type="astr">FALSE</Record>


### PR DESCRIPTION
When WAN Manager selection is enabled for the cellular interface, we observe that the cellular interface can come up faster than the Ethernet, resulting in it being selected as a primary WAN.

To resolve this issue, move the cellular interface into WAN Manager group 2.
The SFP interface (eth8) that was in group 2 is moved into group 1.

The WAN interface selection logic should now resemble:

WAN interface = (Ethernet || SFP) || Cellular
With cellular brought up as a standby interface, when available.

edit 2026-07-01: the change from #126 is cherry picked into this merge. #126 was merged prematurely