### PR TITLE
rdk-wifi-libhostap: remove Broadcom related patch / compile fix

### DIFF
--- a/meta-rdk-broadband/recipes-ccsp/ccsp/rdk-wifi-libhostap.bbappend
+++ b/meta-rdk-broadband/recipes-ccsp/ccsp/rdk-wifi-libhostap.bbappend
@@ -1,2 +1,6 @@
 # 2026-04-20 compile error due to undeclared "own_mld_id" variable
 SRC_URI:remove = "file://${HOSTAPD_PV}/MLO_Correct_PerStaProfile_rx_link_id.patch"
+
+# 2026-06-30 compile error due to patch not applying cleanly
+# (original change was BCOMB-3508)
+SRC_URI:remove = "file://${HOSTAPD_PV}/iPhone17_connection_fix.patch"


### PR DESCRIPTION
BCOMB-3508[1] patch does not apply to our tree. The patch contents are related to Broadcom only, so there is no impact from removing it.

We previously removed the Broadcom related patch that BCOMB-3508 depends on because it does not compile, I have checked and the issue is still present:
https://github.com/rdkcentral/meta-rdk-bsp-arm/commit/03b6f572ff52c8e5d5bee69b3df0ab69142208af

```
Hunk #8 FAILED at 4780.
Hunk #9 succeeded at 4953 (offset -32 lines).
Hunk #10 succeeded at 5287 (offset -32 lines).
Hunk #11 succeeded at 5558 (offset -32 lines).
Hunk #12 FAILED at 5624.
2 out of 12 hunks FAILED -- rejects in file source/hostap-2.11/src/ap/ieee802_11.c Patch iPhone17_connection_fix.patch does not apply (enforce with -f)
```

[1] https://code.rdkcentral.com/r/c/rdk/components/generic/rdk-oe/meta-rdk-broadband/+/127259